### PR TITLE
Modify error handler check for locally handled errors.

### DIFF
--- a/bot/exts/evergreen/error_handler.py
+++ b/bot/exts/evergreen/error_handler.py
@@ -42,8 +42,8 @@ class CommandErrorHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
         """Activates when a command opens an error."""
-        if hasattr(ctx.command, 'on_error'):
-            logging.debug("A command error occured but the command had it's own error handler.")
+        if hasattr(error, 'handled'):
+            logging.debug(f"Command {ctx.command} had its error already handled locally; ignoring.")
             return
 
         error = getattr(error, 'original', error)

--- a/bot/exts/evergreen/error_handler.py
+++ b/bot/exts/evergreen/error_handler.py
@@ -42,7 +42,7 @@ class CommandErrorHandler(commands.Cog):
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
         """Activates when a command opens an error."""
-        if hasattr(error, 'handled'):
+        if getattr(error, 'handled', False):
             logging.debug(f"Command {ctx.command} had its error already handled locally; ignoring.")
             return
 

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -15,7 +15,7 @@ import aiohttp
 import async_timeout
 from PIL import Image, ImageDraw, ImageFont
 from discord import Colour, Embed, File, Member, Message, Reaction
-from discord.ext.commands import BadArgument, Bot, Cog, CommandError, Context, bot_has_permissions, group
+from discord.ext.commands import Bot, Cog, CommandError, Context, bot_has_permissions, group
 
 from bot.constants import ERROR_REPLIES, Tokens
 from bot.exts.evergreen.snakes import _utils as utils
@@ -1131,21 +1131,11 @@ class Snakes(Cog):
     @video_command.error
     async def command_error(self, ctx: Context, error: CommandError) -> None:
         """Local error handler for the Snake Cog."""
-        embed = Embed()
-        embed.colour = Colour.red()
-
-        if isinstance(error, BadArgument):
-            embed.description = str(error)
-            embed.title = random.choice(ERROR_REPLIES)
-
-        elif isinstance(error, OSError):
+        if isinstance(error, OSError):
+            error.handled = True
+            embed = Embed()
+            embed.colour = Colour.red()
             log.error(f"snake_card encountered an OSError: {error} ({error.original})")
             embed.description = "Could not generate the snake card! Please try again."
             embed.title = random.choice(ERROR_REPLIES)
-
-        else:
-            log.error(f"Unhandled tag command error: {error} ({error.original})")
-            return
-
-        await ctx.send(embed=embed)
-    # endregion
+            await ctx.send(embed=embed)

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -1126,16 +1126,15 @@ class Snakes(Cog):
     # endregion
 
     # region: Error handlers
-    @get_command.error
     @card_command.error
-    @video_command.error
     async def command_error(self, ctx: Context, error: CommandError) -> None:
         """Local error handler for the Snake Cog."""
-        if isinstance(error, OSError):
+        original_error = getattr(error, "original", None)
+        if isinstance(original_error, OSError):
             error.handled = True
             embed = Embed()
             embed.colour = Colour.red()
-            log.error(f"snake_card encountered an OSError: {error} ({error.original})")
+            log.error(f"snake_card encountered an OSError: {error} ({original_error})")
             embed.description = "Could not generate the snake card! Please try again."
             embed.title = random.choice(ERROR_REPLIES)
             await ctx.send(embed=embed)


### PR DESCRIPTION
closes #538 

Error handler now checks if the error has the attribute "handled" for locally handled errors instead of checking if the command has the attribute "on_error".

## Did you:

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] If dependencies have been added or updated, run `pipenv lock`?
- [X] **Lint your code** (`pipenv run lint`)?
- [X] Set the PR to **allow edits from contributors**?
