### PR TITLE
Aoc2020

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -95,6 +95,7 @@ class Branding:
 class Channels(NamedTuple):
     admins = 365960823622991872
     advent_of_code = int(environ.get("AOC_CHANNEL_ID", 782715290437943306))
+    advent_of_code_commands = int(environ.get("AOC_COMMANDS_CHANNEL_ID", 783503267849437205))
     announcements = int(environ.get("CHANNEL_ANNOUNCEMENTS", 354619224620138496))
     big_brother_logs = 468507907357409333
     bot = 267659945086812160

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -95,7 +95,7 @@ class Branding:
 class Channels(NamedTuple):
     admins = 365960823622991872
     advent_of_code = int(environ.get("AOC_CHANNEL_ID", 782715290437943306))
-    advent_of_code_commands = int(environ.get("AOC_COMMANDS_CHANNEL_ID", 783503267849437205))
+    advent_of_code_commands = int(environ.get("AOC_COMMANDS_CHANNEL_ID", 607247579608121354))
     announcements = int(environ.get("CHANNEL_ANNOUNCEMENTS", 354619224620138496))
     big_brother_logs = 468507907357409333
     bot = 267659945086812160

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -21,7 +21,7 @@ AOC_REQUEST_HEADER = {"user-agent": "PythonDiscord AoC Event Bot"}
 
 COUNTDOWN_STEP = 60 * 5
 
-AOC_WHITELIST = WHITELISTED_CHANNELS + (Channels.advent_of_code,)
+AOC_WHITELIST = WHITELISTED_CHANNELS + (Channels.advent_of_code_commands,)
 
 
 async def countdown_status(bot: commands.Bot) -> None:
@@ -139,7 +139,7 @@ class AdventOfCode(commands.Cog):
         aliases=("sub", "notifications", "notify", "notifs"),
         brief="Notifications for new days"
     )
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST + (Channels.advent_of_code))
     async def aoc_subscribe(self, ctx: commands.Context) -> None:
         """Assign the role for notifications about new days being ready."""
         current_year = datetime.now().year
@@ -160,7 +160,7 @@ class AdventOfCode(commands.Cog):
 
     @in_month(Month.DECEMBER)
     @adventofcode_group.command(name="unsubscribe", aliases=("unsub",), brief="Notifications for new days")
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST + Channels.advent_of_code)
     async def aoc_unsubscribe(self, ctx: commands.Context) -> None:
         """Remove the role for notifications about new days being ready."""
         role = ctx.guild.get_role(AocConfig.role_id)
@@ -172,7 +172,7 @@ class AdventOfCode(commands.Cog):
             await ctx.send("Hey, you don't even get any notifications about new Advent of Code tasks currently anyway.")
 
     @adventofcode_group.command(name="countdown", aliases=("count", "c"), brief="Return time left until next day")
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST + (Channels.advent_of_code))
     async def aoc_countdown(self, ctx: commands.Context) -> None:
         """Return time left until next day."""
         if not _helpers.is_in_advent():
@@ -207,7 +207,7 @@ class AdventOfCode(commands.Cog):
         await ctx.send("", embed=self.cached_about_aoc)
 
     @adventofcode_group.command(name="join", aliases=("j",), brief="Learn how to join the leaderboard (via DM)")
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST + (Channels.advent_of_code))
     async def join_leaderboard(self, ctx: commands.Context) -> None:
         """DM the user the information for joining the Python Discord leaderboard."""
         current_year = datetime.now().year

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -374,5 +374,5 @@ class AdventOfCode(commands.Cog):
     async def cog_command_error(self, ctx: commands.Context, error: Exception) -> None:
         """Custom error handler if an advent of code command was posted in the wrong channel."""
         if isinstance(error, InChannelCheckFailure):
-            await ctx.send(f":x: Please use <#{Channels.advent_of_code_commands}> for aoc commands instead, please.")
+            await ctx.send(f":x: Please use <#{Channels.advent_of_code_commands}> for aoc commands instead.")
             error.handled = True

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -376,5 +376,3 @@ class AdventOfCode(commands.Cog):
         if isinstance(error, InChannelCheckFailure):
             await ctx.send(f":x: Please use <#{Channels.advent_of_code_commands}> for aoc commands instead, please.")
             error.handled = True
-        else:
-            raise error

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -375,6 +375,6 @@ class AdventOfCode(commands.Cog):
         """Custom error handler if an advent of code command was posted in the wrong channel."""
         if isinstance(error, InChannelCheckFailure):
             await ctx.send(f":x: Please use <#{Channels.advent_of_code_commands}> for aoc commands instead, please.")
-            ctx.command.on_error = True
+            error.handled = True
         else:
             raise error

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -21,11 +21,11 @@ AOC_REQUEST_HEADER = {"user-agent": "PythonDiscord AoC Event Bot"}
 
 COUNTDOWN_STEP = 60 * 5
 
-AOC_WHITELIST = WHITELISTED_CHANNELS + (Channels.advent_of_code_commands,)
+AOC_WHITELIST_RESTRICTED = WHITELISTED_CHANNELS + (Channels.advent_of_code_commands,)
 
 # Some commands can be run in the regular advent of code channel
 # They aren't spammy and foster discussion
-AOC_WHITELIST_PLUS = AOC_WHITELIST + (Channels.advent_of_code,)
+AOC_WHITELIST = AOC_WHITELIST_RESTRICTED + (Channels.advent_of_code,)
 
 
 async def countdown_status(bot: commands.Bot) -> None:
@@ -132,7 +132,7 @@ class AdventOfCode(commands.Cog):
         self.status_task = self.bot.loop.create_task(status_coro)
 
     @commands.group(name="adventofcode", aliases=("aoc",))
-    @override_in_channel(AOC_WHITELIST_PLUS)
+    @override_in_channel(AOC_WHITELIST)
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         if not ctx.invoked_subcommand:
@@ -143,7 +143,7 @@ class AdventOfCode(commands.Cog):
         aliases=("sub", "notifications", "notify", "notifs"),
         brief="Notifications for new days"
     )
-    @override_in_channel(AOC_WHITELIST_PLUS)
+    @override_in_channel(AOC_WHITELIST)
     async def aoc_subscribe(self, ctx: commands.Context) -> None:
         """Assign the role for notifications about new days being ready."""
         current_year = datetime.now().year
@@ -164,7 +164,7 @@ class AdventOfCode(commands.Cog):
 
     @in_month(Month.DECEMBER)
     @adventofcode_group.command(name="unsubscribe", aliases=("unsub",), brief="Notifications for new days")
-    @override_in_channel(AOC_WHITELIST_PLUS)
+    @override_in_channel(AOC_WHITELIST)
     async def aoc_unsubscribe(self, ctx: commands.Context) -> None:
         """Remove the role for notifications about new days being ready."""
         role = ctx.guild.get_role(AocConfig.role_id)
@@ -176,7 +176,7 @@ class AdventOfCode(commands.Cog):
             await ctx.send("Hey, you don't even get any notifications about new Advent of Code tasks currently anyway.")
 
     @adventofcode_group.command(name="countdown", aliases=("count", "c"), brief="Return time left until next day")
-    @override_in_channel(AOC_WHITELIST_PLUS)
+    @override_in_channel(AOC_WHITELIST)
     async def aoc_countdown(self, ctx: commands.Context) -> None:
         """Return time left until next day."""
         if not _helpers.is_in_advent():
@@ -211,7 +211,7 @@ class AdventOfCode(commands.Cog):
         await ctx.send("", embed=self.cached_about_aoc)
 
     @adventofcode_group.command(name="join", aliases=("j",), brief="Learn how to join the leaderboard (via DM)")
-    @override_in_channel(AOC_WHITELIST_PLUS)
+    @override_in_channel(AOC_WHITELIST)
     async def join_leaderboard(self, ctx: commands.Context) -> None:
         """DM the user the information for joining the Python Discord leaderboard."""
         current_year = datetime.now().year
@@ -260,7 +260,7 @@ class AdventOfCode(commands.Cog):
         aliases=("board", "lb"),
         brief="Get a snapshot of the PyDis private AoC leaderboard",
     )
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST_RESTRICTED)
     async def aoc_leaderboard(self, ctx: commands.Context) -> None:
         """Get the current top scorers of the Python Discord Leaderboard."""
         async with ctx.typing():
@@ -285,7 +285,7 @@ class AdventOfCode(commands.Cog):
         aliases=("globalboard", "gb"),
         brief="Get a link to the global leaderboard",
     )
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST_RESTRICTED)
     async def aoc_global_leaderboard(self, ctx: commands.Context) -> None:
         """Get a link to the global Advent of Code leaderboard."""
         url = self.global_leaderboard_url
@@ -301,7 +301,7 @@ class AdventOfCode(commands.Cog):
         aliases=("dailystats", "ds"),
         brief="Get daily statistics for the Python Discord leaderboard"
     )
-    @override_in_channel(AOC_WHITELIST)
+    @override_in_channel(AOC_WHITELIST_RESTRICTED)
     async def private_leaderboard_daily_stats(self, ctx: commands.Context) -> None:
         """Send an embed with daily completion statistics for the Python Discord leaderboard."""
         try:


### PR DESCRIPTION
## Description & Reasoning
Some of the advent of code commands can be rather "spammy" and clog up the primary channel when there's good discussion going on. This PR aims to limit some of the advent of code commands to `#aoc-commands` and only allow the shorter ones that are more likely to foster discussion in the primary channel. 


## Screenshots
Image of what happens if a user tries to use the `.aoc stats` command in the primary channel, followed by subscribe.
![image](https://user-images.githubusercontent.com/20641196/100900518-ec572080-3490-11eb-80be-e959b05a5bb0.png)



## Additional Details
Requires #540 to be merged first.


## Did you:
- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] If dependencies have been added or updated, run `pipenv lock`?
- [X] **Lint your code** (`pipenv run lint`)?
- [X] Set the PR to **allow edits from contributors**?
