### PR TITLE
Migrate to IGDB V4 API

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -174,7 +174,7 @@ class Emojis:
     christmas_tree = "\U0001F384"
     check = "\u2611"
     envelope = "\U0001F4E8"
-    trashcan = "<:trashcan:796854840293589003>"
+    trashcan = "<:trashcan:637136429717389331>"
     ok_hand = ":ok_hand:"
 
     dice_1 = "<:dice_1:755891608859443290>"

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -174,7 +174,7 @@ class Emojis:
     christmas_tree = "\U0001F384"
     check = "\u2611"
     envelope = "\U0001F4E8"
-    trashcan = "<:trashcan:637136429717389331>"
+    trashcan = "<:trashcan:796854840293589003>"
     ok_hand = ":ok_hand:"
 
     dice_1 = "<:dice_1:755891608859443290>"
@@ -257,7 +257,8 @@ class Tokens(NamedTuple):
     youtube = environ.get("YOUTUBE_API_KEY")
     tmdb = environ.get("TMDB_API_KEY")
     nasa = environ.get("NASA_API_KEY")
-    igdb = environ.get("IGDB_API_KEY")
+    igdb_client_id = environ.get("IGDB_CLIENT_ID")
+    igdb_client_secret = environ.get("IGDB_CLIENT_SECRET")
     github = environ.get("GITHUB_TOKEN")
 
 

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -171,7 +171,10 @@ class Games(Cog):
                             f"OAuth response message: {result['message']}"
                         )
                     else:
-                        logger.warning("Invalid OAuth credentials. Unloading Games cog.")
+                        logger.warning(
+                            "Invalid OAuth credentials. Unloading Games cog. "
+                            f"OAuth response message: {result['message']}"
+                        )
                         self.bot.remove_cog('Games')
 
                     return

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -23,6 +23,9 @@ BASE_URL = "https://api.igdb.com/v4"
 CLIENT_ID = Tokens.igdb_client_id
 CLIENT_SECRET = Tokens.igdb_client_secret
 
+# The number of seconds before expiry that we attempt to re-fetch a new access token
+ACCESS_TOKEN_RENEWAL_WINDOW = 60*60*24*2
+
 # URL to request API access token
 OAUTH_URL = "https://id.twitch.tv/oauth2/token"
 
@@ -168,8 +171,8 @@ class Games(Cog):
 
             self.access_token = result["access_token"]
 
-            # Set next renewal to 2 days before expire time
-            next_renewal = result["expires_in"] - 60*60*24*2
+            # Attempt to renew before the token expires
+            next_renewal = result["expires_in"] - ACCESS_TOKEN_RENEWAL_WINDOW
 
             time_delta = timedelta(seconds=next_renewal)
             logger.info(f"Successfully renewed access token. Refreshing again in {time_delta}")

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -151,7 +151,7 @@ class Games(Cog):
 
         self.bot.loop.create_task(self.renew_access_token())
 
-        # self.refresh_genres_task.start()
+        self.refresh_genres_task.start()
 
     async def renew_access_token(self) -> None:
         """Refeshes V4 access token 2 days before expiry."""


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #548

## TODOs
- [x] Use OAuth flow to get an access token
- [x] Try to renew access token before it expires
- [x] Change all interactions with API to use new endpoints
- [x] Make sure the data we use is still available and in the same format
- [x] Deal with the new rate limits imposed by the V4 API

## Description
<!-- Describe how you've implemented your changes. -->
1. Changed env vars from a single api token, to the client id and client secret 
2. Added a background task to the Games cog to re-fetch an OAuth key before the current one expires, currently set to do it 2 days before expiry, but can be easily changed if we want more notice.
3. If first attempt to get OAuth access token fails, unload the cog.
4. If attempts to renew OAuth access token fail, raise error but continue to use current token.
5. Delay the start of the `refresh_genres_task` until we get an OAuth access token.
6. Change all `get` requests to `post` requests.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
1. This is required by the new OAuth flow of V4
2. Instead of using a set period of time and using a `@task.loop()` a background task like this allows us to vary the amount of time between expiry and when we renew.
3. The env vars aren't valid, so no need to keep the cog loaded
4. This could be caused by the client id/secret being changed. If this happens, the access token will still be valid, so we can keep using it, but raise error so it can be actioned.
5. This will fail without a valid access token, so we need to wait until the first iteration of the renewal loop
6. This is a requirement of the V4 API

## Additional Details
<!-- Delete this section if not applicable. -->
Added imports of `asyncio.sleep` for the renewal loop, and `datetime.timedelta` to make it easy to format the valid length of the current access token

V4 of the API introduces rate limits on the endpoints. These seem to be getting handled automatically, so no conscious effort has been made to deal with them in this PR.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
