### PR TITLE
Actually use 256 colours

### DIFF
--- a/bot/exts/evergreen/8bitify.py
+++ b/bot/exts/evergreen/8bitify.py
@@ -19,7 +19,7 @@ class EightBitify(commands.Cog):
     @staticmethod
     def quantize(image: Image) -> Image:
         """Reduces colour palette to 256 colours."""
-        return image.quantize(colors=32)
+        return image.quantize()
 
     @commands.command(name="8bitify")
     async def eightbit_command(self, ctx: commands.Context) -> None:


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Close #431

## Description
<!-- Describe how you've implemented your changes. -->
Removed default parameter override.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
The default option for `colors` is 256, the number of colours 8-bit graphics has.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
Before:
![image](https://user-images.githubusercontent.com/9753350/104107720-737c8d00-52b6-11eb-8397-6c2a231e1c85.png)
After:
![image](https://user-images.githubusercontent.com/9753350/104107728-81321280-52b6-11eb-96de-ebfc63a308a5.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
