### PR TITLE
Add curl User Agent Headers

### DIFF
--- a/bot/exts/evergreen/cheatsheet.py
+++ b/bot/exts/evergreen/cheatsheet.py
@@ -26,6 +26,7 @@ If the problem persists send a message in <#{Channels.dev_contrib}>
 URL = 'https://cheat.sh/python/{search}'
 ESCAPE_TT = str.maketrans({"`": "\\`"})
 ANSI_RE = re.compile(r"\x1b\[.*?m")
+# We need to pass headers as curl otherwise it would default to aiohttp which would return raw html.
 HEADERS = {'User-Agent': 'curl/7.68.0'}
 
 

--- a/bot/exts/evergreen/cheatsheet.py
+++ b/bot/exts/evergreen/cheatsheet.py
@@ -26,6 +26,7 @@ If the problem persists send a message in <#{Channels.dev_contrib}>
 URL = 'https://cheat.sh/python/{search}'
 ESCAPE_TT = str.maketrans({"`": "\\`"})
 ANSI_RE = re.compile(r"\x1b\[.*?m")
+HEADERS = {'User-Agent': 'curl/7.68.0'}
 
 
 class CheatSheet(commands.Cog):
@@ -92,7 +93,7 @@ class CheatSheet(commands.Cog):
             search_string = quote_plus(" ".join(search_terms))
 
             async with self.bot.http_session.get(
-                    URL.format(search=search_string)
+                    URL.format(search=search_string), headers=HEADERS
             ) as response:
                 result = ANSI_RE.sub("", await response.text()).translate(ESCAPE_TT)
 


### PR DESCRIPTION
## Description
Fixes `cheatsheet` command, which was sending raw html output as [`cht.sh` ](https://github.com/chubin/cheat.sh) had reverted the change of `aiohttp` User Agent. To fix this, I have added `curl/7.68.0` as the User Agent which is being passed through `headers`.

## Screenshots
**Before:**
![Screenshot from 2021-02-08 05-54-53](https://user-images.githubusercontent.com/69356296/107163902-2fbe9580-69d2-11eb-8b5c-3aaf598c4437.png)

**After:**
![Screenshot from 2021-02-08 05-53-36](https://user-images.githubusercontent.com/69356296/107163873-07cf3200-69d2-11eb-8e41-db92184f5046.png)


## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
