### PR TITLE
Add location mocks to the wolfram cog

### DIFF
--- a/bot/exts/evergreen/wolfram.py
+++ b/bot/exts/evergreen/wolfram.py
@@ -108,7 +108,10 @@ async def get_pod_pages(ctx: Context, bot: commands.Bot, query: str) -> Optional
             "input": query,
             "appid": APPID,
             "output": DEFAULT_OUTPUT_FORMAT,
-            "format": "image,plaintext"
+            "format": "image,plaintext",
+            "location": "the moon",
+            "latlong": "0.0,0.0",
+            "ip": "1.1.1.1"
         })
         request_url = QUERY.format(request="query", data=url_str)
 

--- a/bot/exts/evergreen/wolfram.py
+++ b/bot/exts/evergreen/wolfram.py
@@ -171,6 +171,9 @@ class Wolfram(Cog):
         url_str = parse.urlencode({
             "i": query,
             "appid": APPID,
+            "location": "the moon",
+            "latlong": "0.0,0.0",
+            "ip": "1.1.1.1"
         })
         query = QUERY.format(request="simple", data=url_str)
 
@@ -251,6 +254,9 @@ class Wolfram(Cog):
         url_str = parse.urlencode({
             "i": query,
             "appid": APPID,
+            "location": "the moon",
+            "latlong": "0.0,0.0",
+            "ip": "1.1.1.1"
         })
         query = QUERY.format(request="result", data=url_str)
 


### PR DESCRIPTION
Previously the server IP address could be leaked using some query such as “what is the weather here?” or simply “what’s my ip?”. This aims to fix it by using mock locations.