### PR TITLE
Reset valentine command cooldown on failure

### DIFF
--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -86,17 +86,17 @@ class BeMyValentine(commands.Cog):
             # This command should only be used in the server
             msg = "You are supposed to use this command in the server."
             await ctx.send(msg)
-            return
+            raise commands.UserInputError
 
         if Lovefest.role_id not in [role.id for role in user.roles]:
             message = f"You cannot send a valentine to {user} as they do not have the lovefest role!"
             await ctx.send(message)
-            return
+            raise commands.UserInputError
 
         if user == ctx.author:
             # Well a user can't valentine himself/herself.
             await ctx.send("Come on, you can't send a valentine to yourself :expressionless:")
-            return
+            raise commands.UserInputError
 
         emoji_1, emoji_2 = self.random_emoji()
         channel = self.bot.get_channel(Channels.community_bot_commands)
@@ -131,12 +131,12 @@ class BeMyValentine(commands.Cog):
                 await ctx.author.send(message)
             except discord.Forbidden:
                 await ctx.send(message)
-            return
+            raise commands.UserInputError
 
         if user == ctx.author:
             # Well a user cant valentine himself/herself.
             await ctx.send('Come on, you can\'t send a valentine to yourself :expressionless:')
-            return
+            raise commands.UserInputError
 
         emoji_1, emoji_2 = self.random_emoji()
         valentine, title = self.valentine_check(valentine_type)
@@ -151,6 +151,7 @@ class BeMyValentine(commands.Cog):
             await ctx.message.delete()
         except discord.Forbidden:
             await ctx.send(f"{user} has DMs disabled, so I couldn't send the message. Sorry!")
+            raise commands.UserInputError
         else:
             await ctx.author.send(f"Your message has been sent to {user}")
 

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -124,7 +124,7 @@ class BeMyValentine(commands.Cog):
         if Lovefest.role_id not in [role.id for role in user.roles]:
             await ctx.message.delete()
             raise commands.UserInputError(
-                f"You cannot send a valentine to {user}> as they do not have the lovefest role!"
+                f"You cannot send a valentine to {user} as they do not have the lovefest role!"
             )
 
         if user == ctx.author:

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -84,19 +84,16 @@ class BeMyValentine(commands.Cog):
         """
         if ctx.guild is None:
             # This command should only be used in the server
-            msg = "You are supposed to use this command in the server."
-            await ctx.send(msg)
-            raise commands.UserInputError
+            raise commands.UserInputError("You are supposed to use this command in the server.")
 
         if Lovefest.role_id not in [role.id for role in user.roles]:
-            message = f"You cannot send a valentine to {user} as they do not have the lovefest role!"
-            await ctx.send(message)
-            raise commands.UserInputError
+            raise commands.UserInputError(
+                f"You cannot send a valentine to {user} as they do not have the lovefest role!"
+            )
 
         if user == ctx.author:
             # Well a user can't valentine himself/herself.
-            await ctx.send("Come on, you can't send a valentine to yourself :expressionless:")
-            raise commands.UserInputError
+            raise commands.UserInputError("Come on, you can't send a valentine to yourself :expressionless:")
 
         emoji_1, emoji_2 = self.random_emoji()
         channel = self.bot.get_channel(Channels.community_bot_commands)
@@ -125,18 +122,14 @@ class BeMyValentine(commands.Cog):
         Iceman in DM making you anonymous)
         """
         if Lovefest.role_id not in [role.id for role in user.roles]:
-            message = f"You cannot send a valentine to {user} as they do not have the lovefest role!"
             await ctx.message.delete()
-            try:
-                await ctx.author.send(message)
-            except discord.Forbidden:
-                await ctx.send(message)
-            raise commands.UserInputError
+            raise commands.UserInputError(
+                f"You cannot send a valentine to {user}> as they do not have the lovefest role!"
+            )
 
         if user == ctx.author:
             # Well a user cant valentine himself/herself.
-            await ctx.send('Come on, you can\'t send a valentine to yourself :expressionless:')
-            raise commands.UserInputError
+            raise commands.UserInputError("Come on, you can't send a valentine to yourself :expressionless:")
 
         emoji_1, emoji_2 = self.random_emoji()
         valentine, title = self.valentine_check(valentine_type)
@@ -146,12 +139,11 @@ class BeMyValentine(commands.Cog):
             description=f'{valentine} \n **{emoji_2}From anonymous{emoji_1}**',
             color=Colours.pink
         )
+        await ctx.message.delete()
         try:
             await user.send(embed=embed)
-            await ctx.message.delete()
         except discord.Forbidden:
-            await ctx.send(f"{user} has DMs disabled, so I couldn't send the message. Sorry!")
-            raise commands.UserInputError
+            raise commands.UserInputError(f"{user} has DMs disabled, so I couldn't send the message. Sorry!")
         else:
             await ctx.author.send(f"Your message has been sent to {user}")
 


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
By raising `UserInputError` the `on_command_error` listener `bot/exts/evergreen/error_handler:43` will reset the command cooldown and output a usage embed. By passing the error message as a string to `UserInputError` it now gets displayed within the same embed, rather than two messages.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
The reset cd already exists functionality, so raising the error utilizes already implemented & tested code.

## Screenshots
Usage embed when sending to yourself
![image](https://user-images.githubusercontent.com/9753350/107863504-d1b80500-6e4c-11eb-877e-8cdd3a6c0169.png)

 Usage embed when sending to someone with DMs disabled
![image](https://user-images.githubusercontent.com/9753350/107863512-dc729a00-6e4c-11eb-84fd-3482d484390d.png)

Usage embed when sending to someone without lovefest role
![image](https://user-images.githubusercontent.com/9753350/107863577-6e7aa280-6e4d-11eb-9f7d-31ce2247ace0.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
