### PR TITLE
Add WTF Python Command

### DIFF
--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -60,8 +60,8 @@ class WTFPython(commands.Cog):
                 log.trace("Fetching the latest WTF Python README.md")
 
                 if resp.status == 200:
-                    self.raw = await resp.text()
-                    await self.parse_readme(self.raw)
+                    raw = await resp.text()
+                    self.parse_readme(raw)
                     log.debug("Successfully fetched the latest WTF Python README.md, breaking out of retry loop")
                     break
 
@@ -86,7 +86,7 @@ class WTFPython(commands.Cog):
         else:
             log.debug(f"Extension {verb}ed: `{ext}`.")
 
-    async def parse_readme(self, data: str) -> None:
+    def parse_readme(self, data: str) -> None:
         """
         Parses the README.md into a dict.
 

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -14,7 +14,7 @@ from bot.bot import Bot
 
 log = logging.getLogger(__name__)
 
-WTF_PYTHON_RAW_URL = "http://raw.githubusercontent.com/satwikkansal/wtfpython/master/"
+WTF_PYTHON_RAW_URL = "http://raw.githubusercontent.com/satwikkansal/wtfpython/mster/"
 BASE_URL = "https://github.com/satwikkansal/wtfpython"
 FETCH_TRIES = 3
 
@@ -72,12 +72,13 @@ class WTFPython(commands.Cog):
                     )
 
         if failed_tries == 3:
+            log.error("Couldn't fetch WTF Python README.md after 3 tries, unloading extension.")
             action = Action.UNLOAD
         else:
             action = Action.LOAD
 
         verb = action.name.lower()
-        ext = self.__class__.__name__
+        ext = "bot.exts.evergreen.wtf_python"
 
         try:
             action.value(self.bot, ext)

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -53,7 +53,9 @@ class WTFPython(commands.Cog):
         """
         Parses the README.md into a dict.
 
-        Key is the name of the section and link to it.
+        It parses the readme into the `self.headers` dict,
+        where the key is the heading and the value is the
+        link to the heading.
         """
         table_of_contents = re.findall(
             r"\[👀 Examples\]\(#-examples\)\n([\w\W]*)<!-- tocstop -->", data
@@ -71,10 +73,7 @@ class WTFPython(commands.Cog):
 
     def fuzzy_match_header(self, query: str) -> Optional[str]:
         """Returns the fuzzy match of a query if its ratio is above 90 else returns None."""
-        match, certainty = process.extractOne(
-            query,
-            list(self.headers.keys())
-        )
+        match, certainty = process.extractOne(query, self.headers.keys())
         return match if certainty > 90 else None
 
     @staticmethod

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -37,12 +37,11 @@ class WTFPython(commands.Cog):
         self.bot = bot
         self.get_wtf_python_readme.start()
 
-        self.data: dict = {}
         self.headers: Dict[str] = dict()
 
     @tasks.loop(hours=1)
     async def get_wtf_python_readme(self) -> None:
-        """Gets content of README.md of WTF Python Repository."""
+        """"Gets the content of README.md from the WTF Python Repository."""
         async with self.bot.http_session.get(WTF_PYTHON_RAW_URL) as resp:
             if resp.status == 200:
                 self.raw = await resp.text()
@@ -71,13 +70,9 @@ class WTFPython(commands.Cog):
                 )
 
     def fuzzy_match_header(self, query: str) -> Optional[str]:
-        """Returns the fizzy match of a query if its ratio is above 90 else returns None."""
-        keys = list(self.headers.keys())
-        match = process.extractOne(query, keys)
-        print(match)
-        if match[1] < 90:
-            return
-        return match[0]
+         """Returns the fuzzy match of a query if its ratio is above 90 else returns None."""
+        match, certainty = process.extractOne(query, list(self.headers.keys()))
+        return match if certainty > 90 else None
 
     @staticmethod
     async def make_embed(query: str, link: str) -> Embed:

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -1,0 +1,117 @@
+import logging
+import random
+import re
+from typing import Dict, Optional
+
+from discord import Embed
+from discord.ext import commands, tasks
+from fuzzywuzzy import process
+
+from bot import constants
+from bot.bot import Bot
+
+log = logging.getLogger(__name__)
+
+WTF_PYTHON_RAW_URL = ("http://raw.githubusercontent.com/satwikkansal/"
+                      "wtfpython/master/README.md")
+BASE_URL = "https://github.com/satwikkansal/wtfpython"
+THUMBNAIL = "https://raw.githubusercontent.com/satwikkansal/wtfpython/master/images/logo.png"
+
+ERROR_MESSAGE = f"""
+Unknown WTF Python Query. Please try to reformulate your query.
+
+**Examples**:
+```md
+{constants.Client.prefix}wtf wild imports
+{constants.Client.prefix}wtf subclass
+{constants.Client.prefix}wtf del
+```
+If the problem persists send a message in <#{constants.Channels.dev_contrib}>
+"""
+
+
+class WTFPython(commands.Cog):
+    """Cog that allows users to retrieve issues from GitHub."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.get_wtf_python_readme.start()
+
+        self.data: dict = {}
+        self.headers: Dict[str] = dict()
+
+    @tasks.loop(hours=1)
+    async def get_wtf_python_readme(self) -> None:
+        """Gets content of README.md of WTF Python Repository."""
+        async with self.bot.http_session.get(WTF_PYTHON_RAW_URL) as resp:
+            if resp.status == 200:
+                self.raw = await resp.text()
+                await self.parse_readme(self.raw)
+            else:
+                log.debug(f"Failed to get latest WTF Python README.md. Status code {resp.status}")
+
+    async def parse_readme(self, data: str) -> None:
+        """
+        Parses the README.md into a dict.
+
+        Key is the name of the section and link to it.
+        """
+        table_of_contents = re.findall(
+            r"\[👀 Examples\]\(#-examples\)\n([\w\W]*)<!-- tocstop -->", data
+        )[0].split("\n")
+        table_of_contents = list(map(str.strip, table_of_contents))
+
+        for header in table_of_contents:
+            match = re.findall(r"\[▶ (.*)\]\((.*)\)", header)
+            if match:
+                self.headers.update(
+                    {
+                        match[0][0]: f"{BASE_URL}{match[0][1]}"
+                    }
+                )
+
+    def fuzzy_match_header(self, query: str) -> Optional[str]:
+        """Returns the fizzy match of a query if its ratio is above 90 else returns None."""
+        keys = list(self.headers.keys())
+        match = process.extractOne(query, keys)
+        print(match)
+        if match[1] < 90:
+            return
+        return match[0]
+
+    @staticmethod
+    async def make_embed(query: str, link: str) -> Embed:
+        """Generates a embed for a search."""
+        embed = Embed(
+            title=f"WTF Python Search Result For {query}",
+            colour=constants.Colours.dark_green,
+            description=f"[Go to Repository Section]({link})"
+        )
+        embed.set_thumbnail(url=THUMBNAIL)
+        return embed
+
+    @commands.command(aliases=("wtf",))
+    async def wtf_python(self, ctx: commands.Context, *query: str) -> None:
+        """
+        Search wtf python.
+
+        Gets the link of the fuzzy matched query from https://github.com/satwikkansal/wtfpython.
+        Usage:
+            --> .wtf wild imports
+        """
+        query = " ".join(query)
+        match = self.fuzzy_match_header(query)
+        if not match:
+            embed = Embed(
+                title=random.choice(constants.ERROR_REPLIES),
+                description=ERROR_MESSAGE,
+                colour=constants.Colours.soft_red
+            )
+        else:
+            embed = await self.make_embed(query, self.headers[match])
+        await ctx.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    """Load WTFPython Cog."""
+    bot.add_cog(WTFPython(bot))

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -14,7 +14,7 @@ from bot.bot import Bot
 
 log = logging.getLogger(__name__)
 
-WTF_PYTHON_RAW_URL = "http://raw.githubusercontent.com/satwikkansal/wtfpython/mster/"
+WTF_PYTHON_RAW_URL = "http://raw.githubusercontent.com/satwikkansal/wtfpython/master/"
 BASE_URL = "https://github.com/satwikkansal/wtfpython"
 FETCH_TRIES = 3
 

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -81,14 +81,10 @@ class WTFPython(commands.Cog):
 
         try:
             action.value(self.bot, ext)
-        except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotLoaded):
-            log.debug(
-                f"Reached maximum failed `FETCH_TRIES`.\n\nExtension `{ext}` is already  is already {verb}ed.."
-            )
+        except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotLoaded) as e:
+            log.debug(f"Extension `{ext}` is already  is already {verb}ed.")
         else:
-            log.debug(
-                f"Reached maximum failed `FETCH_TRIES`.\n\nExtension {verb}ed: `{ext}`."
-            )
+            log.debug(f"Extension {verb}ed: `{ext}`.")
 
     async def parse_readme(self, data: str) -> None:
         """

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -79,7 +79,7 @@ class WTFPython(commands.Cog):
         return match if certainty > MINIMUM_CERTAINTY else None
 
     @staticmethod
-    async def make_embed(query: str, link: str) -> Embed:
+    def make_embed(query: str, link: str) -> Embed:
         """Generates a embed for a search."""
         embed = Embed(
             title=f"WTF Python Search Result For {query}",
@@ -107,7 +107,7 @@ class WTFPython(commands.Cog):
                 colour=constants.Colours.soft_red
             )
         else:
-            embed = await self.make_embed(query, self.headers[match])
+            embed = self.make_embed(query, self.headers[match])
         await ctx.send(embed=embed)
 
 

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -29,6 +29,8 @@ Unknown WTF Python Query. Please try to reformulate your query.
 If the problem persists send a message in <#{constants.Channels.dev_contrib}>
 """
 
+MINIMUM_CERTAINTY = 75
+
 
 class WTFPython(commands.Cog):
     """Cog that allows users to retrieve issues from GitHub."""
@@ -74,7 +76,7 @@ class WTFPython(commands.Cog):
     def fuzzy_match_header(self, query: str) -> Optional[str]:
         """Returns the fuzzy match of a query if its ratio is above 90 else returns None."""
         match, certainty = process.extractOne(query, self.headers.keys())
-        return match if certainty > 90 else None
+        return match if certainty > MINIMUM_CERTAINTY else None
 
     @staticmethod
     async def make_embed(query: str, link: str) -> Embed:

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -57,12 +57,12 @@ class WTFPython(commands.Cog):
 
         for x in range(FETCH_TRIES):
             async with self.bot.http_session.get(f"{WTF_PYTHON_RAW_URL}README.md") as resp:
-                log.trace(f"Fetching the latest WTF Python README.md")
+                log.trace("Fetching the latest WTF Python README.md")
 
                 if resp.status == 200:
                     self.raw = await resp.text()
                     await self.parse_readme(self.raw)
-                    log.debug(f"Successfully fetched the latest WTF Python README.md, breaking out of retry loop")
+                    log.debug("Successfully fetched the latest WTF Python README.md, breaking out of retry loop")
                     break
 
                 else:
@@ -81,7 +81,7 @@ class WTFPython(commands.Cog):
 
         try:
             action.value(self.bot, ext)
-        except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotLoaded) as e:
+        except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotLoaded):
             log.debug(f"Extension `{ext}` is already  is already {verb}ed.")
         else:
             log.debug(f"Extension {verb}ed: `{ext}`.")

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -82,7 +82,7 @@ class WTFPython(commands.Cog):
         try:
             action.value(self.bot, ext)
         except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotLoaded):
-            log.debug(f"Extension `{ext}` is already  is already {verb}ed.")
+            log.debug(f"Extension `{ext}` is already {verb}ed.")
         else:
             log.debug(f"Extension {verb}ed: `{ext}`.")
 
@@ -113,19 +113,8 @@ class WTFPython(commands.Cog):
         match, certainty = process.extractOne(query, self.headers.keys())
         return match if certainty > MINIMUM_CERTAINTY else None
 
-    @staticmethod
-    def make_embed(query: str, link: str) -> Embed:
-        """Generates a embed for a search."""
-        embed = Embed(
-            title=f"WTF Python Search Result For {query}",
-            colour=constants.Colours.dark_green,
-            description=f"[Go to Repository Section]({link})"
-        )
-        embed.set_thumbnail(url=f"{WTF_PYTHON_RAW_URL}images/logo.png")
-        return embed
-
     @commands.command(aliases=("wtf",))
-    async def wtf_python(self, ctx: commands.Context, *query: str) -> None:
+    async def wtf_python(self, ctx: commands.Context, *, query: str) -> None:
         """
         Search wtf python.
 
@@ -133,7 +122,6 @@ class WTFPython(commands.Cog):
         Usage:
             --> .wtf wild imports
         """
-        query = " ".join(query)
         match = self.fuzzy_match_header(query)
         if not match:
             embed = Embed(
@@ -142,7 +130,12 @@ class WTFPython(commands.Cog):
                 colour=constants.Colours.soft_red
             )
         else:
-            embed = self.make_embed(query, self.headers[match])
+            embed = Embed(
+                title=f"WTF Python Search Result For {query}",
+                colour=constants.Colours.dark_green,
+                description=f"[Go to Repository Section]({self.headers[match]})"
+            )
+            embed.set_thumbnail(url=f"{WTF_PYTHON_RAW_URL}images/logo.png")
         await ctx.send(embed=embed)
 
 

--- a/bot/exts/evergreen/wtf_python.py
+++ b/bot/exts/evergreen/wtf_python.py
@@ -41,7 +41,7 @@ class WTFPython(commands.Cog):
 
     @tasks.loop(hours=1)
     async def get_wtf_python_readme(self) -> None:
-        """"Gets the content of README.md from the WTF Python Repository."""
+        """Gets the content of README.md from the WTF Python Repository."""
         async with self.bot.http_session.get(WTF_PYTHON_RAW_URL) as resp:
             if resp.status == 200:
                 self.raw = await resp.text()
@@ -70,8 +70,11 @@ class WTFPython(commands.Cog):
                 )
 
     def fuzzy_match_header(self, query: str) -> Optional[str]:
-         """Returns the fuzzy match of a query if its ratio is above 90 else returns None."""
-        match, certainty = process.extractOne(query, list(self.headers.keys()))
+        """Returns the fuzzy match of a query if its ratio is above 90 else returns None."""
+        match, certainty = process.extractOne(
+            query,
+            list(self.headers.keys())
+        )
         return match if certainty > 90 else None
 
     @staticmethod


### PR DESCRIPTION
## Relevant Issues
Closes #602 


## Description
Gets the fuzzy match of a search query, returns `None` if the ratio is below `90` else returns the fuzzy match. If the return is `None`, then we send our custom Error Message else it sends the link to the subsection of the WTF Python README.md.


## Reasoning
Approved by a staff.


## Screenshots
**On Dark Theme**

![Screenshot from 2021-03-02 15-22-56](https://user-images.githubusercontent.com/69356296/109631103-a67f2680-7b6b-11eb-942b-d396bd267d24.png)

**On Light Theme**


![Screenshot from 2021-03-02 15-22-43](https://user-images.githubusercontent.com/69356296/109631111-a848ea00-7b6b-11eb-86a4-a79935aa9ac3.png)

(I went blind while teking it, and am helf blind rihgt now, so ignre ayn spellign misteke)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
