### PR TITLE
Fixes Startup Channel Check Bug

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -74,11 +74,16 @@ class Bot(commands.Bot):
     async def check_channels(self) -> None:
         """Verifies that all channel constants refer to channels which exist."""
         await self.wait_until_guild_available()
-        all_channels = set(self.get_all_channels())
+
+        if constants.Client.debug:
+            log.info("Skipping Channels Check.")
+            return
+
+        all_channels_ids = [channel.id for channel in set(self.get_all_channels())]
         for name, channel_id in vars(constants.Channels).items():
             if name.startswith('_'):
                 continue
-            if channel_id not in all_channels:
+            if channel_id not in all_channels_ids:
                 log.error(f'Channel "{name}" with ID {channel_id} missing')
 
     async def send_log(self, title: str, details: str = None, *, icon: str = None) -> None:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -79,7 +79,7 @@ class Bot(commands.Bot):
             log.info("Skipping Channels Check.")
             return
 
-        all_channels_ids = [channel.id for channel in set(self.get_all_channels())]
+        all_channels_ids = [channel.id for channel in self.get_all_channels()]
         for name, channel_id in vars(constants.Channels).items():
             if name.startswith('_'):
                 continue


### PR DESCRIPTION
## Relevant Issues
Closes #606


## Description
Uses `channel.id`s instead of `channel` object while checking for missing channels. Skips the check if `debug` is set to `False` in the `.env`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
