### PR TITLE
Teapot support

### DIFF
--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -1,71 +1,49 @@
-from http import HTTPStatus
-
 import discord
-from discord.ext import commands
+from discord.ext.commands import Bot, Cog, Context, group
 
 HTTP_DOG_URL = "https://httpstatusdogs.com/img/{code}.jpg"
 HTTP_CAT_URL = "https://http.cat/{code}.jpg"
+STATUS_TEMPLATE = '**Status: {code}**'
+ERR_404 = 'Unable to find status Floof for {code}.'
+ERR_UNKNOWN = 'Error attempting to retrieve status Floof for {code}.'
 
 
-class HTTPStatusCodes(commands.Cog):
+class HTTPStatusCodes(Cog):
     """Commands that give HTTP statuses described and visualized by cats and dogs."""
 
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: Bot):
         self.bot = bot
 
-    @commands.group(name="http_status", aliases=("status", "httpstatus"))
-    async def http_status_group(self, ctx: commands.Context) -> None:
+    @group(name="http_status", aliases=("status", "httpstatus"))
+    async def http_status_group(self, ctx: Context) -> None:
         """Group containing dog and cat http status code commands."""
         if not ctx.invoked_subcommand:
             await ctx.send_help(ctx.command)
 
     @http_status_group.command(name='cat')
-    async def http_cat(self, ctx: commands.Context, code: int) -> None:
-        """Sends an embed with an image of a cat, portraying the status code."""
-        embed = discord.Embed(title=f'**Status: {code}**')
-        url = HTTP_CAT_URL.format(code=code)
-
-        try:
-            HTTPStatus(code)
-            async with self.bot.http_session.get(url, allow_redirects=False) as response:
-                if response.status != 404:
-                    embed.set_image(url=url)
-                else:
-                    raise NotImplementedError
-
-        except ValueError:
-            embed.set_footer(text='Inputted status code does not exist.')
-
-        except NotImplementedError:
-            embed.set_footer(text='Inputted status code is not implemented by http.cat yet.')
-
-        finally:
-            await ctx.send(embed=embed)
+    async def http_cat(self, ctx: Context, code: int) -> None:
+        """Assemble Cat URL and build Embed."""
+        await self.build_embed(url=HTTP_CAT_URL.format(code), ctx=ctx, code=code)
 
     @http_status_group.command(name='dog')
-    async def http_dog(self, ctx: commands.Context, code: int) -> None:
-        """Sends an embed with an image of a dog, portraying the status code."""
-        embed = discord.Embed(title=f'**Status: {code}**')
-        url = HTTP_DOG_URL.format(code=code)
+    async def http_dog(self, ctx: Context, code: int) -> None:
+        """Assemble Dog URL and build Embed."""
+        await self.build_embed(url=HTTP_DOG_URL.format(code), ctx=ctx, code=code)
 
-        try:
-            HTTPStatus(code)
-            async with self.bot.http_session.get(url, allow_redirects=False) as response:
-                if response.status != 302:
-                    embed.set_image(url=url)
-                else:
-                    raise NotImplementedError
-
-        except ValueError:
-            embed.set_footer(text='Inputted status code does not exist.')
-
-        except NotImplementedError:
-            embed.set_footer(text='Inputted status code is not implemented by httpstatusdogs.com yet.')
-
-        finally:
-            await ctx.send(embed=embed)
+    async def build_embed(self, url: str, code: int, ctx: Context, ) -> None:
+        """Attempt to build and dispatch embed. Append error message instead of something goes wrong."""
+        async with self.bot.http_session.get(url, allow_redirects=False) as response:
+            if 200 <= response.status <= 299:
+                await ctx.send(embed=discord.Embed(title=STATUS_TEMPLATE.format(code), url=url))
+            elif 404 == response.status:
+                await ctx.send(embed=discord.Embed(title=STATUS_TEMPLATE.format(response.status), url=url))
+            else:
+                await ctx.send(embed=discord.Embed(
+                    title=STATUS_TEMPLATE.format(code),
+                    footer=ERR_404.format(code) if response.status == 404 else ERR_UNKNOWN.format(code))
+                )
 
 
-def setup(bot: commands.Bot) -> None:
+def setup(bot: Bot) -> None:
     """Load the HTTPStatusCodes cog."""
     bot.add_cog(HTTPStatusCodes(bot))

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext.commands import Bot, Cog, Context, group
+from discord.ext import commands
 
 HTTP_DOG_URL = "https://httpstatusdogs.com/img/{code}.jpg"
 HTTP_CAT_URL = "https://http.cat/{code}.jpg"
@@ -8,48 +8,44 @@ ERR_404 = 'Unable to find status Floof for {code}.'
 ERR_UNKNOWN = 'Error attempting to retrieve status Floof for {code}.'
 
 
-class HTTPStatusCodes(Cog):
+class HTTPStatusCodes(commands.Cog):
     """Commands that give HTTP statuses described and visualized by cats and dogs."""
 
-    def __init__(self, bot: Bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @group(name="http_status", aliases=("status", "httpstatus"))
-    async def http_status_group(self, ctx: Context) -> None:
+    @commands.group(name="http_status", aliases=("status", "httpstatus"))
+    async def http_status_group(self, ctx: commands.Context) -> None:
         """Group containing dog and cat http status code commands."""
         if not ctx.invoked_subcommand:
             await ctx.send_help(ctx.command)
 
     @http_status_group.command(name='cat')
-    async def http_cat(self, ctx: Context, code: int) -> None:
+    async def http_cat(self, ctx: commands.Context, code: int) -> None:
         """Assemble Cat URL and build Embed."""
-        await self.build_embed(url=HTTP_CAT_URL.format(code), ctx=ctx, code=code)
+        await self.build_embed(url=HTTP_CAT_URL.format(code=code), ctx=ctx, code=code)
 
     @http_status_group.command(name='dog')
-    async def http_dog(self, ctx: Context, code: int) -> None:
+    async def http_dog(self, ctx: commands.Context, code: int) -> None:
         """Assemble Dog URL and build Embed."""
-        await self.build_embed(url=HTTP_DOG_URL.format(code), ctx=ctx, code=code)
+        await self.build_embed(url=HTTP_DOG_URL.format(code=code), ctx=ctx, code=code)
 
-    async def build_embed(self, url: str, code: int, ctx: Context, ) -> None:
+    async def build_embed(self, url: str, ctx: commands.Context, code: int) -> None:
         """Attempt to build and dispatch embed. Append error message instead if something goes wrong."""
         async with self.bot.http_session.get(url, allow_redirects=False) as response:
             if 200 <= response.status <= 299:
                 await ctx.send(embed=discord.Embed(
-                    title=STATUS_TEMPLATE.format(code),
-                    url=url
-                ))
+                    title=STATUS_TEMPLATE.format(code=code)).set_image(url=url))
             elif 404 == response.status:
                 await ctx.send(embed=discord.Embed(
-                    title=ERR_404.format(code),
-                    url=url
-                ))
+                    title=ERR_404.format(code=code)).set_image(url=url)
+                )
             else:
                 await ctx.send(embed=discord.Embed(
-                    title=STATUS_TEMPLATE.format(code),
-                    footer=ERR_UNKNOWN.format(code)
-                ))
+                    title=STATUS_TEMPLATE.format(code=code), footer=ERR_UNKNOWN.format(code=code))
+                )
 
 
-def setup(bot: Bot) -> None:
+def setup(bot: commands.Bot) -> None:
     """Load the HTTPStatusCodes cog."""
     bot.add_cog(HTTPStatusCodes(bot))

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -31,15 +31,23 @@ class HTTPStatusCodes(Cog):
         await self.build_embed(url=HTTP_DOG_URL.format(code), ctx=ctx, code=code)
 
     async def build_embed(self, url: str, code: int, ctx: Context, ) -> None:
-        """Attempt to build and dispatch embed. Append error message instead of something goes wrong."""
+        """Attempt to build and dispatch embed. Append error message instead if something goes wrong."""
         async with self.bot.http_session.get(url, allow_redirects=False) as response:
             if 200 <= response.status <= 299:
-                await ctx.send(embed=discord.Embed(title=STATUS_TEMPLATE.format(code), url=url))
+                await ctx.send(embed=discord.Embed(
+                    title=STATUS_TEMPLATE.format(code),
+                    url=url
+                ))
+            elif 404 == response.status:
+                await ctx.send(embed=discord.Embed(
+                    title=ERR_404.format(code),
+                    url=url
+                ))
             else:
                 await ctx.send(embed=discord.Embed(
                     title=STATUS_TEMPLATE.format(code),
-                    footer=ERR_404.format(code) if response.status == 404 else ERR_UNKNOWN.format(code))
-                )
+                    footer=ERR_UNKNOWN.format(code)
+                ))
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
## Relevant Issues
Closes #428 
Closes #500
Closes #608


## Description
Removed HTTPStatus from the equation entirely in favor of just relying on the cat/dog servers to send us back errors if we get bad input. 

Minor refactor to pull strings out of the executable code into variables at the top. 

## Reasoning
Implemented design and strategy suggested by staff in #608 discussion. 

## Screenshots
<img width="563" alt="Screen Shot 2021-03-03 at 8 16 13 AM" src="https://user-images.githubusercontent.com/410320/109811480-e2ac9880-7bf8-11eb-9108-6fc976270483.png">
<img width="568" alt="Screen Shot 2021-03-03 at 8 16 18 AM" src="https://user-images.githubusercontent.com/410320/109811489-e50ef280-7bf8-11eb-9a05-2aec97450d56.png">

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] If dependencies have been added or updated, run `pipenv lock`?
- [X] **Lint your code** (`pipenv run lint`)?
- [ ] Set the PR to **allow edits from contributors**? *Edits allowed from maintainers, contributors doesn't appear to be an option*
