### PR TITLE
change ctx.send_help to ctx.invoke(help_command)

### DIFF
--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -52,7 +52,7 @@ class AdventOfCode(commands.Cog):
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         if not ctx.invoked_subcommand:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
 
     @adventofcode_group.command(
         name="subscribe",

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -51,7 +51,8 @@ class AdventOfCode(commands.Cog):
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         if not ctx.invoked_subcommand:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
 
     @adventofcode_group.command(
         name="subscribe",

--- a/bot/exts/christmas/advent_of_code/_cog.py
+++ b/bot/exts/christmas/advent_of_code/_cog.py
@@ -12,6 +12,7 @@ from bot.constants import (
 )
 from bot.exts.christmas.advent_of_code import _helpers
 from bot.utils.decorators import InChannelCheckFailure, in_month, whitelist_override, with_role
+from bot.utils.extensions import invoke_help_command
 
 log = logging.getLogger(__name__)
 
@@ -51,8 +52,7 @@ class AdventOfCode(commands.Cog):
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         if not ctx.invoked_subcommand:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
 
     @adventofcode_group.command(
         name="subscribe",

--- a/bot/exts/evergreen/emoji.py
+++ b/bot/exts/evergreen/emoji.py
@@ -76,7 +76,7 @@ class Emojis(commands.Cog):
         if emoji is not None:
             await ctx.invoke(self.info_command, emoji)
         else:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
 
     @emoji_group.command(name="count", aliases=("c",))
     async def count_command(self, ctx: commands.Context, *, category_query: str = None) -> None:

--- a/bot/exts/evergreen/emoji.py
+++ b/bot/exts/evergreen/emoji.py
@@ -11,6 +11,7 @@ from discord.ext import commands
 from bot.constants import Colours, ERROR_REPLIES
 from bot.utils.pagination import LinePaginator
 from bot.utils.time import time_since
+from bot.utils.extensions import invoke_help_command
 
 log = logging.getLogger(__name__)
 
@@ -75,8 +76,7 @@ class Emojis(commands.Cog):
         if emoji is not None:
             await ctx.invoke(self.info_command, emoji)
         else:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
 
     @emoji_group.command(name="count", aliases=("c",))
     async def count_command(self, ctx: commands.Context, *, category_query: str = None) -> None:

--- a/bot/exts/evergreen/emoji.py
+++ b/bot/exts/evergreen/emoji.py
@@ -75,7 +75,8 @@ class Emojis(commands.Cog):
         if emoji is not None:
             await ctx.invoke(self.info_command, emoji)
         else:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
 
     @emoji_group.command(name="count", aliases=("c",))
     async def count_command(self, ctx: commands.Context, *, category_query: str = None) -> None:

--- a/bot/exts/evergreen/emoji.py
+++ b/bot/exts/evergreen/emoji.py
@@ -9,9 +9,9 @@ from discord import Color, Embed, Emoji
 from discord.ext import commands
 
 from bot.constants import Colours, ERROR_REPLIES
+from bot.utils.extensions import invoke_help_command
 from bot.utils.pagination import LinePaginator
 from bot.utils.time import time_since
-from bot.utils.extensions import invoke_help_command
 
 log = logging.getLogger(__name__)
 

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -15,8 +15,8 @@ from discord.ext.commands import Cog, Context, group
 from bot.bot import Bot
 from bot.constants import STAFF_ROLES, Tokens
 from bot.utils.decorators import with_role
-from bot.utils.pagination import ImagePaginator, LinePaginator
 from bot.utils.extensions import invoke_help_command
+from bot.utils.pagination import ImagePaginator, LinePaginator
 
 # Base URL of IGDB API
 BASE_URL = "https://api.igdb.com/v4"

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -235,7 +235,7 @@ class Games(Cog):
         """
         # When user didn't specified genre, send help message
         if genre is None:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
             return
 
         # Capitalize genre for check

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -234,7 +234,8 @@ class Games(Cog):
         """
         # When user didn't specified genre, send help message
         if genre is None:
-            await ctx.send_help("games")
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
             return
 
         # Capitalize genre for check

--- a/bot/exts/evergreen/game.py
+++ b/bot/exts/evergreen/game.py
@@ -16,6 +16,7 @@ from bot.bot import Bot
 from bot.constants import STAFF_ROLES, Tokens
 from bot.utils.decorators import with_role
 from bot.utils.pagination import ImagePaginator, LinePaginator
+from bot.utils.extensions import invoke_help_command
 
 # Base URL of IGDB API
 BASE_URL = "https://api.igdb.com/v4"
@@ -234,8 +235,7 @@ class Games(Cog):
         """
         # When user didn't specified genre, send help message
         if genre is None:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
             return
 
         # Capitalize genre for check

--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 
 from bot.constants import Client
 from bot.utils.exceptions import UserNotPlayingError
+from bot.utils.extensions import invoke_help_command
 
 MESSAGE_MAPPING = {
     0: ":stop_button:",
@@ -83,8 +84,7 @@ class Minesweeper(commands.Cog):
     @commands.group(name='minesweeper', aliases=('ms',), invoke_without_command=True)
     async def minesweeper_group(self, ctx: commands.Context) -> None:
         """Commands for Playing Minesweeper."""
-        help_command = ctx.bot.get_command("help")
-        await ctx.invoke(help_command, ctx.command.name)
+        await invoke_help_command(ctx, ctx.command.name)
 
     @staticmethod
     def get_neighbours(x: int, y: int) -> typing.Generator[typing.Tuple[int, int], None, None]:

--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -83,7 +83,8 @@ class Minesweeper(commands.Cog):
     @commands.group(name='minesweeper', aliases=('ms',), invoke_without_command=True)
     async def minesweeper_group(self, ctx: commands.Context) -> None:
         """Commands for Playing Minesweeper."""
-        await ctx.send_help(ctx.command)
+        help_command = ctx.bot.get_command("help")
+        await ctx.invoke(help_command, ctx.command.name)
 
     @staticmethod
     def get_neighbours(x: int, y: int) -> typing.Generator[typing.Tuple[int, int], None, None]:

--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -84,7 +84,7 @@ class Minesweeper(commands.Cog):
     @commands.group(name='minesweeper', aliases=('ms',), invoke_without_command=True)
     async def minesweeper_group(self, ctx: commands.Context) -> None:
         """Commands for Playing Minesweeper."""
-        await invoke_help_command(ctx, ctx.command.name)
+        await invoke_help_command(ctx)
 
     @staticmethod
     def get_neighbours(x: int, y: int) -> typing.Generator[typing.Tuple[int, int], None, None]:

--- a/bot/exts/evergreen/movie.py
+++ b/bot/exts/evergreen/movie.py
@@ -74,7 +74,7 @@ class Movie(Cog):
         try:
             result = await self.get_movies_list(self.http_session, MovieGenres[genre].value, 1)
         except KeyError:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
             return
 
         # Check if "results" is in result. If not, throw error.

--- a/bot/exts/evergreen/movie.py
+++ b/bot/exts/evergreen/movie.py
@@ -10,6 +10,7 @@ from discord.ext.commands import Bot, Cog, Context, group
 
 from bot.constants import Tokens
 from bot.utils.pagination import ImagePaginator
+from bot.utils.extensions import invoke_help_command
 
 # Define base URL of TMDB
 BASE_URL = "https://api.themoviedb.org/3/"
@@ -73,8 +74,7 @@ class Movie(Cog):
         try:
             result = await self.get_movies_list(self.http_session, MovieGenres[genre].value, 1)
         except KeyError:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
             return
 
         # Check if "results" is in result. If not, throw error.

--- a/bot/exts/evergreen/movie.py
+++ b/bot/exts/evergreen/movie.py
@@ -73,7 +73,8 @@ class Movie(Cog):
         try:
             result = await self.get_movies_list(self.http_session, MovieGenres[genre].value, 1)
         except KeyError:
-            await ctx.send_help('movies')
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
             return
 
         # Check if "results" is in result. If not, throw error.

--- a/bot/exts/evergreen/movie.py
+++ b/bot/exts/evergreen/movie.py
@@ -9,8 +9,8 @@ from discord import Embed
 from discord.ext.commands import Bot, Cog, Context, group
 
 from bot.constants import Tokens
-from bot.utils.pagination import ImagePaginator
 from bot.utils.extensions import invoke_help_command
+from bot.utils.pagination import ImagePaginator
 
 # Define base URL of TMDB
 BASE_URL = "https://api.themoviedb.org/3/"

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -440,7 +440,8 @@ class Snakes(Cog):
     @group(name='snakes', aliases=('snake',), invoke_without_command=True)
     async def snakes_group(self, ctx: Context) -> None:
         """Commands from our first code jam."""
-        await ctx.send_help(ctx.command)
+        help_command = self.bot.get_command("help")
+        await ctx.invoke(help_command, ctx.command.name)
 
     @bot_has_permissions(manage_messages=True)
     @snakes_group.command(name='antidote')

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -441,7 +441,7 @@ class Snakes(Cog):
     @group(name='snakes', aliases=('snake',), invoke_without_command=True)
     async def snakes_group(self, ctx: Context) -> None:
         """Commands from our first code jam."""
-        await invoke_help_command(ctx, ctx.command.name)
+        await invoke_help_command(ctx)
 
     @bot_has_permissions(manage_messages=True)
     @snakes_group.command(name='antidote')

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -22,6 +22,7 @@ from bot.constants import ERROR_REPLIES, Tokens
 from bot.exts.evergreen.snakes import _utils as utils
 from bot.exts.evergreen.snakes._converter import Snake
 from bot.utils.decorators import locked
+from bot.utils.extensions import invoke_help_command
 
 log = logging.getLogger(__name__)
 
@@ -440,8 +441,7 @@ class Snakes(Cog):
     @group(name='snakes', aliases=('snake',), invoke_without_command=True)
     async def snakes_group(self, ctx: Context) -> None:
         """Commands from our first code jam."""
-        help_command = self.bot.get_command("help")
-        await ctx.invoke(help_command, ctx.command.name)
+        await invoke_help_command(ctx, ctx.command.name)
 
     @bot_has_permissions(manage_messages=True)
     @snakes_group.command(name='antidote')

--- a/bot/exts/evergreen/space.py
+++ b/bot/exts/evergreen/space.py
@@ -64,7 +64,7 @@ class Space(Cog):
     @group(name="space", invoke_without_command=True)
     async def space(self, ctx: Context) -> None:
         """Head command that contains commands about space."""
-        await invoke_help_command(ctx, ctx.command.name)
+        await invoke_help_command(ctx)
 
     @space.command(name="apod")
     async def apod(self, ctx: Context, date: Optional[str] = None) -> None:

--- a/bot/exts/evergreen/space.py
+++ b/bot/exts/evergreen/space.py
@@ -10,6 +10,7 @@ from discord.ext.commands import BadArgument, Cog, Context, Converter, group
 
 from bot.bot import Bot
 from bot.constants import Tokens
+from bot.utils.extensions import invoke_help_command
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +64,7 @@ class Space(Cog):
     @group(name="space", invoke_without_command=True)
     async def space(self, ctx: Context) -> None:
         """Head command that contains commands about space."""
-        help_command = self.bot.get_command("help")
-        await ctx.invoke(help_command, ctx.command.name)
+        await invoke_help_command(ctx, ctx.command.name)
 
     @space.command(name="apod")
     async def apod(self, ctx: Context, date: Optional[str] = None) -> None:

--- a/bot/exts/evergreen/space.py
+++ b/bot/exts/evergreen/space.py
@@ -63,7 +63,8 @@ class Space(Cog):
     @group(name="space", invoke_without_command=True)
     async def space(self, ctx: Context) -> None:
         """Head command that contains commands about space."""
-        await ctx.send_help("space")
+        help_command = self.bot.get_command("help")
+        await ctx.invoke(help_command, ctx.command.name)
 
     @space.command(name="apod")
     async def apod(self, ctx: Context, date: Optional[str] = None) -> None:

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 
 import discord
 from discord.ext import commands
+from bot.utils.extensions import invoke_help_command
 
 HTTP_DOG_URL = "https://httpstatusdogs.com/img/{code}.jpg"
 HTTP_CAT_URL = "https://http.cat/{code}.jpg"
@@ -17,8 +18,7 @@ class HTTPStatusCodes(commands.Cog):
     async def http_status_group(self, ctx: commands.Context) -> None:
         """Group containing dog and cat http status code commands."""
         if not ctx.invoked_subcommand:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
 
     @http_status_group.command(name='cat')
     async def http_cat(self, ctx: commands.Context, code: int) -> None:

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -19,7 +19,7 @@ class HTTPStatusCodes(commands.Cog):
     async def http_status_group(self, ctx: commands.Context) -> None:
         """Group containing dog and cat http status code commands."""
         if not ctx.invoked_subcommand:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
 
     @http_status_group.command(name='cat')
     async def http_cat(self, ctx: commands.Context, code: int) -> None:

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 
 import discord
 from discord.ext import commands
+
 from bot.utils.extensions import invoke_help_command
 
 HTTP_DOG_URL = "https://httpstatusdogs.com/img/{code}.jpg"

--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -17,7 +17,8 @@ class HTTPStatusCodes(commands.Cog):
     async def http_status_group(self, ctx: commands.Context) -> None:
         """Group containing dog and cat http status code commands."""
         if not ctx.invoked_subcommand:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
 
     @http_status_group.command(name='cat')
     async def http_cat(self, ctx: commands.Context, code: int) -> None:

--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -77,7 +77,7 @@ class Extensions(commands.Cog):
     @group(name="extensions", aliases=("ext", "exts", "c", "cogs"), invoke_without_command=True)
     async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list loaded extensions."""
-        await invoke_help_command(ctx, ctx.command.name)
+        await invoke_help_command(ctx)
 
     @extensions_group.command(name="load", aliases=("l",))
     async def load_command(self, ctx: Context, *extensions: Extension) -> None:
@@ -87,7 +87,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
         if not extensions:
-            await invoke_help_command(ctx, "extensions", ctx.command.name)
+            await invoke_help_command(ctx)
             return
 
         if "*" in extensions or "**" in extensions:
@@ -104,7 +104,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
         if not extensions:
-            await invoke_help_command(ctx, "extensions", ctx.command.name)
+            await invoke_help_command(ctx)
             return
 
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
@@ -130,7 +130,7 @@ class Extensions(commands.Cog):
         If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """  # noqa: W605
         if not extensions:
-            await invoke_help_command(ctx, "extensions", ctx.command.name)
+            await invoke_help_command(ctx)
             return
 
         if "**" in extensions:

--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -11,7 +11,7 @@ from bot import exts
 from bot.bot import Bot
 from bot.constants import Client, Emojis, MODERATION_ROLES, Roles
 from bot.utils.checks import with_role_check
-from bot.utils.extensions import EXTENSIONS, unqualify
+from bot.utils.extensions import EXTENSIONS, unqualify, invoke_help_command
 from bot.utils.pagination import LinePaginator
 
 log = logging.getLogger(__name__)
@@ -77,8 +77,7 @@ class Extensions(commands.Cog):
     @group(name="extensions", aliases=("ext", "exts", "c", "cogs"), invoke_without_command=True)
     async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list loaded extensions."""
-        help_command = self.bot.get_command("help")
-        await ctx.invoke(help_command, ctx.command.name)
+        await invoke_help_command(ctx, ctx.command.name)
 
     @extensions_group.command(name="load", aliases=("l",))
     async def load_command(self, ctx: Context, *extensions: Extension) -> None:
@@ -88,8 +87,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
         if not extensions:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, "extensions", ctx.command.name)
+            await invoke_help_command(ctx, "extensions", ctx.command.name)
             return
 
         if "*" in extensions or "**" in extensions:
@@ -106,8 +104,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
         if not extensions:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, "extensions", ctx.command.name)
+            await invoke_help_command(ctx, "extensions", ctx.command.name)
             return
 
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
@@ -133,8 +130,7 @@ class Extensions(commands.Cog):
         If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """  # noqa: W605
         if not extensions:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, "extensions", ctx.command.name)
+            await invoke_help_command(ctx, "extensions", ctx.command.name)
             return
 
         if "**" in extensions:

--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -11,7 +11,7 @@ from bot import exts
 from bot.bot import Bot
 from bot.constants import Client, Emojis, MODERATION_ROLES, Roles
 from bot.utils.checks import with_role_check
-from bot.utils.extensions import EXTENSIONS, unqualify, invoke_help_command
+from bot.utils.extensions import EXTENSIONS, invoke_help_command, unqualify
 from bot.utils.pagination import LinePaginator
 
 log = logging.getLogger(__name__)

--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -77,7 +77,8 @@ class Extensions(commands.Cog):
     @group(name="extensions", aliases=("ext", "exts", "c", "cogs"), invoke_without_command=True)
     async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list loaded extensions."""
-        await ctx.send_help(ctx.command)
+        help_command = self.bot.get_command("help")
+        await ctx.invoke(help_command, ctx.command.name)
 
     @extensions_group.command(name="load", aliases=("l",))
     async def load_command(self, ctx: Context, *extensions: Extension) -> None:
@@ -87,7 +88,8 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, "extensions", ctx.command.name)
             return
 
         if "*" in extensions or "**" in extensions:
@@ -104,7 +106,8 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, "extensions", ctx.command.name)
             return
 
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
@@ -130,7 +133,8 @@ class Extensions(commands.Cog):
         If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, "extensions", ctx.command.name)
             return
 
         if "**" in extensions:

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -43,7 +43,8 @@ class BeMyValentine(commands.Cog):
         2) use the command \".lovefest unsub\" to get rid of the lovefest role.
         """
         if not ctx.invoked_subcommand:
-            await ctx.send_help(ctx.command)
+            help_command = self.bot.get_command("help")
+            await ctx.invoke(help_command, ctx.command.name)
 
     @lovefest_role.command(name="sub")
     async def add_role(self, ctx: commands.Context) -> None:

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -44,7 +44,7 @@ class BeMyValentine(commands.Cog):
         2) use the command \".lovefest unsub\" to get rid of the lovefest role.
         """
         if not ctx.invoked_subcommand:
-            await invoke_help_command(ctx, ctx.command.name)
+            await invoke_help_command(ctx)
 
     @lovefest_role.command(name="sub")
     async def add_role(self, ctx: commands.Context) -> None:

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -10,6 +10,7 @@ from discord.ext.commands.cooldowns import BucketType
 
 from bot.constants import Channels, Colours, Lovefest, Month
 from bot.utils.decorators import in_month
+from bot.utils.extensions import invoke_help_command
 
 log = logging.getLogger(__name__)
 
@@ -43,8 +44,7 @@ class BeMyValentine(commands.Cog):
         2) use the command \".lovefest unsub\" to get rid of the lovefest role.
         """
         if not ctx.invoked_subcommand:
-            help_command = self.bot.get_command("help")
-            await ctx.invoke(help_command, ctx.command.name)
+            await invoke_help_command(ctx, ctx.command.name)
 
     @lovefest_role.command(name="sub")
     async def add_role(self, ctx: commands.Context) -> None:

--- a/bot/utils/extensions.py
+++ b/bot/utils/extensions.py
@@ -1,10 +1,10 @@
+from discord.ext.commands import Context
 import importlib
 import inspect
 import pkgutil
 from typing import Iterator, NoReturn
 
 from bot import exts
-from discord.ext.commands import Context
 
 
 def unqualify(name: str) -> str:
@@ -33,10 +33,7 @@ def walk_extensions() -> Iterator[str]:
 
 
 async def invoke_help_command(ctx: Context, *commands: str) -> None:
-    """Invoke the help command, and will use the default help command
-       if the help exten is not loaded.
-    """
-
+    """Invoke the help command or default help command if help extensions is not loaded."""
     if 'bot.exts.evergreen.help' in ctx.bot.extensions:
         help_command = ctx.bot.get_command('help')
         await ctx.invoke(help_command, *commands)

--- a/bot/utils/extensions.py
+++ b/bot/utils/extensions.py
@@ -33,12 +33,12 @@ def walk_extensions() -> Iterator[str]:
         yield module.name
 
 
-async def invoke_help_command(ctx: Context, *commands: str) -> None:
+async def invoke_help_command(ctx: Context) -> None:
     """Invoke the help command or default help command if help extensions is not loaded."""
     if 'bot.exts.evergreen.help' in ctx.bot.extensions:
         help_command = ctx.bot.get_command('help')
-        await ctx.invoke(help_command, *commands)
+        await ctx.invoke(help_command, ctx.command.qualified_name)
         return
-    await ctx.send_help(''.join(commands))
+    await ctx.send_help(ctx.command)
 
 EXTENSIONS = frozenset(walk_extensions())

--- a/bot/utils/extensions.py
+++ b/bot/utils/extensions.py
@@ -4,6 +4,7 @@ import pkgutil
 from typing import Iterator, NoReturn
 
 from bot import exts
+from discord.ext.commands import Context
 
 
 def unqualify(name: str) -> str:
@@ -30,5 +31,16 @@ def walk_extensions() -> Iterator[str]:
 
         yield module.name
 
+
+async def invoke_help_command(ctx: Context, *commands: str) -> None:
+    """Invoke the help command, and will use the default help command
+       if the help exten is not loaded.
+    """
+
+    if 'bot.exts.evergreen.help' in ctx.bot.extensions:
+        help_command = ctx.bot.get_command('help')
+        await ctx.invoke(help_command, *commands)
+        return
+    await ctx.send_help(''.join(commands))
 
 EXTENSIONS = frozenset(walk_extensions())

--- a/bot/utils/extensions.py
+++ b/bot/utils/extensions.py
@@ -1,8 +1,9 @@
-from discord.ext.commands import Context
 import importlib
 import inspect
 import pkgutil
 from typing import Iterator, NoReturn
+
+from discord.ext.commands import Context
 
 from bot import exts
 


### PR DESCRIPTION


## Relevant Issues
Closes #624 


## Description
I've changed all the `ctx.send_help`'s to `bot.get_command("help")` and `ctx.invoke(help_command, ctx.command.name)`.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
It looks a lot better.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/78174417/110868352-708e2080-8296-11eb-9f10-b7da2e781311.png)

After:
![image](https://user-images.githubusercontent.com/78174417/110868437-93203980-8296-11eb-8fd5-38ac60d6c654.png)


## Additional Details
Affected commands are `.games`, `.snakes`, `.space`,  `.emoji`, `.minesweeper`, `.movies`, `.status`, `.extensions` (and its subcommands), and `.bemyvalentine`.


## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
