### PR TITLE
Only output override channels & bot commands channel on whitelist error

### DIFF
--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -11,7 +11,7 @@ from discord import Colour, Embed
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Command, Context
 
-from bot.constants import ERROR_REPLIES, Month
+from bot.constants import Channels, ERROR_REPLIES, Month, WHITELISTED_CHANNELS
 from bot.utils import human_months, resolve_current_month
 from bot.utils.checks import in_whitelist_check
 
@@ -252,6 +252,12 @@ def whitelist_check(**default_kwargs: t.Container[int]) -> t.Callable[[Context],
         # Raise error if the check did not pass
         channels = set(kwargs.get("channels") or {})
         categories = kwargs.get("categories")
+
+        # Only output override channels + community_bot_commands
+        if channels:
+            default_whitelist_channels = set(WHITELISTED_CHANNELS)
+            default_whitelist_channels.discard(Channels.community_bot_commands)
+            channels.difference_update(default_whitelist_channels)
 
         # Add all whitelisted category channels
         if categories:

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -266,7 +266,7 @@ def whitelist_check(**default_kwargs: t.Container[int]) -> t.Callable[[Context],
                 if category is None:
                     continue
 
-                [channels.add(channel.id) for channel in category.text_channels]
+                channels.update(channel.id for channel in category.text_channels)
 
         if channels:
             channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #556

## Description
<!-- Describe how you've implemented your changes. -->
Remove all default whitelisted channels from the channel kwarg before building the output string

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Previously this would output all channels, and could result in an error. This change ensures only the main bot channel & and any overridden channels are shown in the embed. We do this before the categories block as the categories kwarg itself is an override, so we want to include those in any output.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
Example where there are no overrides:
![image](https://user-images.githubusercontent.com/9753350/111867797-46132600-896e-11eb-9779-93d7e65f7b27.png)
Example where whitelist includes overrides:
![image](https://user-images.githubusercontent.com/9753350/111867781-3562b000-896e-11eb-98d3-06b39de65b7b.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
