### PR TITLE
Rework permission of `.issue` command.

### DIFF
--- a/bot/exts/evergreen/issues.py
+++ b/bot/exts/evergreen/issues.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands, tasks
 
 from bot.constants import Categories, Channels, Colours, ERROR_REPLIES, Emojis, Tokens, WHITELISTED_CHANNELS
+from bot.utils.decorators import whitelist_override
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ if GITHUB_TOKEN := Tokens.github:
 WHITELISTED_CATEGORIES = (
     Categories.development, Categories.devprojects, Categories.media, Categories.staff
 )
-WHITELISTED_CHANNELS_ON_MESSAGE = (
+WHITELISTED_CHANNELS_ISSUES = (
     Channels.organisation, Channels.mod_meta, Channels.mod_tools, Channels.staff_voice
 )
 
@@ -142,6 +143,10 @@ class Issues(commands.Cog):
         return resp
 
     @commands.command(aliases=("pr",))
+    @whitelist_override(
+        categories=WHITELISTED_CATEGORIES,
+        channels=WHITELISTED_CHANNELS_ISSUES
+    )
     async def issue(
             self,
             ctx: commands.Context,
@@ -181,8 +186,8 @@ class Issues(commands.Cog):
     async def on_message(self, message: discord.Message) -> None:
         """Command to retrieve issue(s) from a GitHub repository using automatic linking if matching <repo>#<issue>."""
         if not(
-            message.channel.category.id in WHITELISTED_CATEGORIES
-            or message.channel.id in WHITELISTED_CHANNELS_ON_MESSAGE
+                message.channel.category.id in WHITELISTED_CATEGORIES
+                or message.channel.id in WHITELISTED_CHANNELS_ISSUES
         ):
             return
 


### PR DESCRIPTION
## Relevant Issues
(No issues are opened for this, was discussed in #dev-contrib)


## Description
<!-- Describe how you've implemented your changes. -->
This PR, changes the white listed channels of `.issue` command to the same as that of of `repo#issue` feature i.e.
```py
WHITELISTED_CATEGORIES = (
    Categories.development, Categories.devprojects, Categories.media, Categories.staff
)
WHITELISTED_CHANNELS_ISSUES = (
    Channels.organisation, Channels.mod_meta, Channels.mod_tools, Channels.staff_voice
)
```

## Reasoning
Was discussed in #dev-contrib, here is the [context](https://discord.com/channels/267624335836053506/635950537262759947/824535356568371210).

Currently the `.issue` command is only allowed in the default whitelisted channels i.e. `ot0, 01-, 02, bot commands, voice-chat-0`. And `.issue` command is used quite a lot in the dev contribute channel, and it is just an alternative to the `repo#issue` feature.
So there is not reason to only `repo#issue` in the whitelisted channels but not `.issue`. 


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
