### PR TITLE
fix: use get_user in 8bitify to avoid events issues

### DIFF
--- a/bot/exts/evergreen/8bitify.py
+++ b/bot/exts/evergreen/8bitify.py
@@ -25,7 +25,8 @@ class EightBitify(commands.Cog):
     async def eightbit_command(self, ctx: commands.Context) -> None:
         """Pixelates your avatar and changes the palette to an 8bit one."""
         async with ctx.typing():
-            image_bytes = await ctx.author.avatar_url.read()
+            author = await self.bot.get_user(ctx.author.id)
+            image_bytes = await author.avatar_url.read()
             avatar = Image.open(BytesIO(image_bytes))
             avatar = avatar.convert("RGBA").resize((1024, 1024))
 

--- a/bot/exts/evergreen/8bitify.py
+++ b/bot/exts/evergreen/8bitify.py
@@ -25,7 +25,7 @@ class EightBitify(commands.Cog):
     async def eightbit_command(self, ctx: commands.Context) -> None:
         """Pixelates your avatar and changes the palette to an 8bit one."""
         async with ctx.typing():
-            author = await self.bot.get_user(ctx.author.id)
+            author = await self.bot.fetch_user(ctx.author.id)
             image_bytes = await author.avatar_url.read()
             avatar = Image.open(BytesIO(image_bytes))
             avatar = avatar.convert("RGBA").resize((1024, 1024))


### PR DESCRIPTION
## Description
Instead of using the cached user the bot now explicitly fetches the user from the API to get the most up to date profile info


## Reasoning
This is because some API events arent going through on pydis (user_update) and the cached user isnt being updated with a new avatar


## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
