### PR TITLE
Migrate GHCR_TOKEN -> GITHUB_TOKEN in Docker build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN  }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
 
       # Build and push the container to the GitHub Container
       # Repository. The container will be tagged as "latest"


### PR DESCRIPTION
## Relevant Issues
Internal decision to migrate, no issue open.


## Description
<!-- Describe how you've implemented your changes. -->
GITHUB_TOKEN has now enough permissions to be used for pushing to GHCR, so we don't need PAT anymore.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
