### PR TITLE
Fix issues with repos not working when typing repo#num

### DIFF
--- a/bot/exts/evergreen/issues.py
+++ b/bot/exts/evergreen/issues.py
@@ -28,7 +28,7 @@ BAD_RESPONSE = {
 MAX_REQUESTS = 10
 REQUEST_HEADERS = dict()
 
-REPOS_API = "https://api.github.com/orgs/{org}/repos"
+REPOS_API = "https://api.github.com/orgs/{org}/repos?per_page=100"
 if GITHUB_TOKEN := Tokens.github:
     REQUEST_HEADERS["Authorization"] = f"token {GITHUB_TOKEN}"
 


### PR DESCRIPTION
## Description
Currently repos such as quackstack don't work with the issues cog when typing, for example, quackstack#29 into discord, since by default GitHub paginates repos to 30 per page, and we only fetch one page.


## Reasoning
Reasoning is to make the functionality work for repos beyond the 30 repo pagination limit, by adding a per_page query string to get 100 per page. This is not a permanent fix, but it should certainly suffice for a long time - another 64 repos.


## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
