### PR TITLE
Add word boundaries to the issues regex

### DIFF
--- a/bot/exts/evergreen/issues.py
+++ b/bot/exts/evergreen/issues.py
@@ -226,7 +226,7 @@ class Issues(commands.Cog):
             return
 
         # `issues` will hold a list of two element tuples `(repository, issue_number)`
-        issues = re.findall(fr"({self.repo_regex})#(\d+)", message.content)
+        issues = re.findall(fr"\b({self.repo_regex})#(\d+)\b", message.content)
         links = []
 
         if issues:


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
Add `\b` characters around the issues regex

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
So we only respond to issues if the regex fully matches a word.

EG sir-lancsdrbot#1 would match bot#1, whereas now it wouldn't match at all.## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
