### PR TITLE
add timed command for timed execution of commands

### DIFF
--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -16,7 +16,7 @@ class TimedCommands(commands.Cog):
 
         return await ctx.bot.get_context(msg)
 
-    @commands.command(name="timed", aliases=["t"])
+    @commands.command(name="timed", aliases=["time", "t"])
     async def timed(self, ctx: commands.Context, *, command: str) -> None:
         """Time the command execution of a command."""
         new_ctx = await self.create_execution_context(ctx, command)

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -1,0 +1,36 @@
+from copy import copy
+from time import perf_counter
+
+from discord import Message
+from discord.ext import commands
+
+
+class TimedCommands(commands.Cog):
+    """Time the command execution of a command."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @staticmethod
+    async def create_execution_context(ctx: commands.Context, command: str) -> commands.Context:
+        """Get a new execution context for a command."""
+        msg: Message = copy(ctx.message)
+        msg._update({"content": f"{ctx.prefix}{command}"})
+
+        return await ctx.bot.get_context(msg)
+
+    @commands.command(name="timed", aliases=["t"])
+    async def timed(self, ctx: commands.Context, *, command: str) -> None:
+        """Time the command execution of a command."""
+        new_ctx = await self.create_execution_context(ctx, command)
+
+        t_start = perf_counter()
+        await new_ctx.command.invoke(new_ctx)
+        t_end = perf_counter()
+
+        await ctx.send(f"Command execution for `{new_ctx.command}` finished in {(t_end - t_start):.4f} seconds.")
+
+
+def setup(bot: commands.Bot) -> None:
+    """Cog load."""
+    bot.add_cog(TimedCommands(bot))

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -8,9 +8,6 @@ from discord.ext import commands
 class TimedCommands(commands.Cog):
     """Time the command execution of a command."""
 
-    def __init__(self, bot: commands.Bot) -> None:
-        self.bot = bot
-
     @staticmethod
     async def create_execution_context(ctx: commands.Context, command: str) -> commands.Context:
         """Get a new execution context for a command."""
@@ -23,6 +20,9 @@ class TimedCommands(commands.Cog):
     async def timed(self, ctx: commands.Context, *, command: str) -> None:
         """Time the command execution of a command."""
         new_ctx = await self.create_execution_context(ctx, command)
+
+        if new_ctx.command and new_ctx.command.qualified_name == "timed":
+            return await ctx.send("You are not allowed to time the execution of the `timed` command.")
 
         t_start = perf_counter()
         await new_ctx.command.invoke(new_ctx)

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -12,7 +12,7 @@ class TimedCommands(commands.Cog):
     async def create_execution_context(ctx: commands.Context, command: str) -> commands.Context:
         """Get a new execution context for a command."""
         msg: Message = copy(ctx.message)
-        msg._update({"content": f"{ctx.prefix}{command}"})
+        msg.content = f"{ctx.prefix}{command}"
 
         return await ctx.bot.get_context(msg)
 
@@ -22,7 +22,8 @@ class TimedCommands(commands.Cog):
         new_ctx = await self.create_execution_context(ctx, command)
 
         if new_ctx.command and new_ctx.command.qualified_name == "timed":
-            return await ctx.send("You are not allowed to time the execution of the `timed` command.")
+            await ctx.send("You are not allowed to time the execution of the `timed` command.")
+            return
 
         t_start = perf_counter()
         await new_ctx.command.invoke(new_ctx)

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -22,7 +22,10 @@ class TimedCommands(commands.Cog):
         new_ctx = await self.create_execution_context(ctx, command)
 
         if not new_ctx.command:
-            await ctx.send("The command you are trying to time doesn't exist. Use `.help` for a list of commands.")
+            help_command = f"{ctx.prefix}help"
+            error = f"The command you are trying to time doesn't exist. Use `{help_command}` for a list of commands."
+
+            await ctx.send(error)
             return
 
         if new_ctx.command.qualified_name == "timed":

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -21,7 +21,11 @@ class TimedCommands(commands.Cog):
         """Time the command execution of a command."""
         new_ctx = await self.create_execution_context(ctx, command)
 
-        if new_ctx.command and new_ctx.command.qualified_name == "timed":
+        if not new_ctx.command:
+            await ctx.send("The command you are trying to time doesn't exist. Use `.help` for a list of commands.")
+            return
+
+        if new_ctx.command.qualified_name == "timed":
             await ctx.send("You are not allowed to time the execution of the `timed` command.")
             return
 


### PR DESCRIPTION
## Relevant Issues
Implements and closes #671 


## Description
The changes have been implemented by creating a new execution context for the command by taking the message content, updating a copy of the message with that content, and using `bot.get_context()` to get a new context for execution. The invokation of that context is then timed by perf_counter() and displayed to the user upon the command finishing with the time in seconds to .4f precision.


## Reasoning
It's been implemented in this way so as to be able to display the time without modifying the original context,


## Screenshots
A normal timed execution:
![image](https://user-images.githubusercontent.com/16879430/114258911-fef2e080-99c1-11eb-9acd-899ca35fd9fc.png)
An attempt at timed execution where command permissions were denied (temporarily role-gated 8bitify command):
![image](https://user-images.githubusercontent.com/16879430/114258924-18942800-99c2-11eb-8adf-692b350f5148.png)
An attempt at timed execution where the command is on cooldown (temporarily cooldowned 8bitify command):
![image](https://user-images.githubusercontent.com/16879430/114258962-5db85a00-99c2-11eb-9a46-ed0573140239.png)
Passing additional command arguments:
![image](https://user-images.githubusercontent.com/16879430/114258973-758fde00-99c2-11eb-8077-acb6e712b017.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
