### PR TITLE
Add an env var for trashcan emoji override

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -153,7 +153,7 @@ class Emojis:
     christmas_tree = "\U0001F384"
     check = "\u2611"
     envelope = "\U0001F4E8"
-    trashcan = "<:trashcan:637136429717389331>"
+    trashcan = environ.get("TRASHCAN_EMOJI", "<:trashcan:637136429717389331>")
     ok_hand = ":ok_hand:"
     hand_raised = "\U0001f64b"
 


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
Added an environ.get with a default value

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Allows users to override the default emoji to their own, which will avoid errors in dev testing.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
