### PR TITLE
fix: put april fools video links in correct channel names

### DIFF
--- a/bot/exts/easter/april_fools_vids.py
+++ b/bot/exts/easter/april_fools_vids.py
@@ -1,32 +1,22 @@
 import logging
 import random
 from json import load
-from pathlib import Path
 
 from discord.ext import commands
 
 log = logging.getLogger(__name__)
 
+with open("bot/resources/easter/april_fools_vids.json", encoding="utf-8") as f:
+    ALL_VIDS = load(f)
+
 
 class AprilFoolVideos(commands.Cog):
     """A cog for April Fools' that gets a random April Fools' video from Youtube."""
 
-    def __init__(self, bot: commands.Bot):
-        self.bot = bot
-        self.yt_vids = self.load_json()
-
-    @staticmethod
-    def load_json() -> dict:
-        """A function to load JSON data."""
-        p = Path('bot/resources/easter/april_fools_vids.json')
-        with p.open(encoding="utf-8") as json_file:
-            all_vids = load(json_file)
-        return all_vids
-
     @commands.command(name='fool')
     async def april_fools(self, ctx: commands.Context) -> None:
         """Get a random April Fools' video from Youtube."""
-        video = random.choice(self.yt_vids)
+        video = random.choice(ALL_VIDS)
 
         channel, url = video["channel"], video["url"]
 

--- a/bot/exts/easter/april_fools_vids.py
+++ b/bot/exts/easter/april_fools_vids.py
@@ -14,7 +14,6 @@ class AprilFoolVideos(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.yt_vids = self.load_json()
-        self.youtubers = ['google']  # will add more in future
 
     @staticmethod
     def load_json() -> dict:
@@ -27,10 +26,11 @@ class AprilFoolVideos(commands.Cog):
     @commands.command(name='fool')
     async def april_fools(self, ctx: commands.Context) -> None:
         """Get a random April Fools' video from Youtube."""
-        random_youtuber = random.choice(self.youtubers)
-        category = self.yt_vids[random_youtuber]
-        random_vid = random.choice(category)
-        await ctx.send(f"Check out this April Fools' video by {random_youtuber}.\n\n{random_vid['link']}")
+        video = random.choice(self.yt_vids)
+
+        channel, url = video["channel"], video["url"]
+
+        await ctx.send(f"Check out this April Fools' video by {channel}.\n\n{url}")
 
 
 def setup(bot: commands.Bot) -> None:

--- a/bot/resources/easter/april_fools_vids.json
+++ b/bot/resources/easter/april_fools_vids.json
@@ -1,136 +1,130 @@
-{
-  "google": [
-    {
-      "title": "Introducing Bad Joke Detector",
-      "link": "https://youtu.be/OYcv406J_J4"
-    },
-    {
-      "title": "Introducing Google Cloud Hummus API - Find your Hummus!",
-      "link": "https://youtu.be/0_5X6N6DHyk"
-    },
-    {
-      "title": "Introducing Google Play for Pets",
-      "link": "https://youtu.be/UmJ2NBHXTqo"
-    },
-    {
-      "title": "Haptic Helpers: bringing you to your senses",
-      "link": "https://youtu.be/3MA6_21nka8"
-    },
-    {
-      "title": "Introducing Google Wind",
-      "link": "https://youtu.be/QAwL0O5nXe0"
-    },
-    {
-      "title": "Experience YouTube in #SnoopaVision",
-      "link": "https://youtu.be/DPEJB-FCItk"
-    },
-    {
-      "title": "Introducing the self-driving bicycle in the Netherlands",
-      "link": "https://youtu.be/LSZPNwZex9s"
-    },
-    {
-      "title": "Android Developer Story: The Guardian goes galactic with Android and Google Play",
-      "link": "https://youtu.be/dFrgNiweQDk"
-    },
-    {
-      "title": "Introducing new delivery technology from Google Express",
-      "link": "https://youtu.be/F0F6SnbqUcE"
-    },
-    {
-      "title": "Google Cardboard Plastic",
-      "link": "https://youtu.be/VkOuShXpoKc"
-    },
-    {
-      "title": "Google Photos: Search your photos by emoji",
-      "link": "https://youtu.be/HQtGFBbwKEk"
-    },
-    {
-      "title": "Introducing Google Actual Cloud Platform",
-      "link": "https://youtu.be/Cp10_PygJ4o"
-    },
-    {
-      "title": "Introducing Dial-Up mode",
-      "link": "https://youtu.be/XTTtkisylQw"
-    },
-    {
-      "title": "Smartbox by Inbox: the mailbox of tomorrow, today",
-      "link": "https://youtu.be/hydLZJXG3Tk"
-    },
-    {
-      "title": "Introducing Coffee to the Home",
-      "link": "https://youtu.be/U2JBFlW--UU"
-    },
-    {
-      "title": "Chrome for Android and iOS: Emojify the Web",
-      "link": "https://youtu.be/G3NXNnoGr3Y"
-    },
-    {
-      "title": "Google Maps: Pokémon Challenge",
-      "link": "https://youtu.be/4YMD6xELI_k"
-    },
-    {
-      "title": "Introducing Google Fiber to the Pole",
-      "link": "https://youtu.be/qcgWRpQP6ds"
-    },
-    {
-      "title": "Introducing Gmail Blue",
-      "link": "https://youtu.be/Zr4JwPb99qU"
-    },
-    {
-      "title": "Introducing Google Nose",
-      "link": "https://youtu.be/VFbYadm_mrw"
-    },
-    {
-      "title": "Explore Treasure Mode with Google Maps",
-      "link": "https://youtu.be/_qFFHC0eIUc"
-    },
-    {
-      "title": "YouTube's ready to select a winner",
-      "link": "https://youtu.be/H542nLTTbu0"
-    },
-    {
-      "title": "A word about Gmail Tap",
-      "link": "https://youtu.be/Je7Xq9tdCJc"
-    },
-    {
-      "title": "Introducing the Google Fiber Bar",
-      "link": "https://youtu.be/re0VRK6ouwI"
-    },
-    {
-      "title": "Introducing Gmail Tap",
-      "link": "https://youtu.be/1KhZKNZO8mQ"
-    },
-    {
-      "title": "Chrome Multitask Mode",
-      "link": "https://youtu.be/UiLSiqyDf4Y"
-    },
-    {
-      "title": "Google Maps 8-bit for NES",
-      "link": "https://youtu.be/rznYifPHxDg"
-    },
-    {
-      "title": "Being a Google Autocompleter",
-      "link": "https://youtu.be/blB_X38YSxQ"
-    },
-    {
-      "title": "Introducing Gmail Motion",
-      "link": "https://youtu.be/Bu927_ul_X0"
-    }
-  ],
-  "nvidia": [
-    {
-      "title": "Introducing GeForce GTX G-Assist",
-      "link": "https://youtu.be/smM-Wdk2RLQ"
-    }
-  ],
-  "razer": [
-    {
-      "title": "The Hovering Mouse - Project McFly | Razer",
-      "link": "https://youtu.be/IlCx5gjAmqI"
-    },
-    {
-      "title": "Be the Machine | Project Venom v2",
-      "link": "https://youtu.be/j8UJE7DoyJ8"
-    }
-  ]
-}
+[
+  {
+    "url": "https://youtu.be/OYcv406J_J4",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/0_5X6N6DHyk",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/UmJ2NBHXTqo",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/3MA6_21nka8",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/QAwL0O5nXe0",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/DPEJB-FCItk",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/LSZPNwZex9s",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/dFrgNiweQDk",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/F0F6SnbqUcE",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/VkOuShXpoKc",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/HQtGFBbwKEk",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/Cp10_PygJ4o",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/XTTtkisylQw",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/hydLZJXG3Tk",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/U2JBFlW--UU",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/G3NXNnoGr3Y",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/4YMD6xELI_k",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/qcgWRpQP6ds",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/Zr4JwPb99qU",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/VFbYadm_mrw",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/_qFFHC0eIUc",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/H542nLTTbu0",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/Je7Xq9tdCJc",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/re0VRK6ouwI",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/1KhZKNZO8mQ",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/UiLSiqyDf4Y",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/rznYifPHxDg",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/blB_X38YSxQ",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/Bu927_ul_X0",
+    "channel": "google"
+  },
+  {
+    "url": "https://youtu.be/smM-Wdk2RLQ",
+    "channel": "nvidia"
+  },
+  {
+    "url": "https://youtu.be/IlCx5gjAmqI",
+    "channel": "razer"
+  },
+  {
+    "url": "https://youtu.be/j8UJE7DoyJ8",
+    "channel": "razer"
+  }
+]

--- a/bot/resources/easter/april_fools_vids.json
+++ b/bot/resources/easter/april_fools_vids.json
@@ -115,11 +115,15 @@
     {
       "title": "Introducing Gmail Motion",
       "link": "https://youtu.be/Bu927_ul_X0"
-    },
+    }
+  ],
+  "nvidia": [
     {
       "title": "Introducing GeForce GTX G-Assist",
       "link": "https://youtu.be/smM-Wdk2RLQ"
-    },
+    }
+  ],
+  "razer": [
     {
       "title": "The Hovering Mouse - Project McFly | Razer",
       "link": "https://youtu.be/IlCx5gjAmqI"
@@ -129,5 +133,4 @@
       "link": "https://youtu.be/j8UJE7DoyJ8"
     }
   ]
-
 }


### PR DESCRIPTION
## Description
A simple fix to put videos in their correct channel names to avoid this: 
![image](https://user-images.githubusercontent.com/16879430/114315826-93f7f580-9af8-11eb-8453-8cc196029c9f.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
