### PR TITLE
fix: display help for the correct command when an error occurs in timed

### DIFF
--- a/bot/exts/evergreen/error_handler.py
+++ b/bot/exts/evergreen/error_handler.py
@@ -46,6 +46,11 @@ class CommandErrorHandler(commands.Cog):
             logging.debug(f"Command {ctx.command} had its error already handled locally; ignoring.")
             return
 
+        parent_command = ""
+        if subctx := getattr(ctx, "subcontext", None):
+            parent_command = f"{ctx.command} "
+            ctx = subctx
+
         error = getattr(error, 'original', error)
         logging.debug(
             f"Error Encountered: {type(error).__name__} - {str(error)}, "
@@ -63,8 +68,9 @@ class CommandErrorHandler(commands.Cog):
 
         if isinstance(error, commands.UserInputError):
             self.revert_cooldown_counter(ctx.command, ctx.message)
+            usage = f"```{ctx.prefix}{parent_command}{ctx.command} {ctx.command.signature}```"
             embed = self.error_embed(
-                f"Your input was invalid: {error}\n\nUsage:\n```{ctx.prefix}{ctx.command} {ctx.command.signature}```"
+                f"Your input was invalid: {error}\n\nUsage:{usage}"
             )
             await ctx.send(embed=embed)
             return
@@ -95,7 +101,7 @@ class CommandErrorHandler(commands.Cog):
             self.revert_cooldown_counter(ctx.command, ctx.message)
             embed = self.error_embed(
                 "The argument you provided was invalid: "
-                f"{error}\n\nUsage:\n```{ctx.prefix}{ctx.command} {ctx.command.signature}```"
+                f"{error}\n\nUsage:\n```{ctx.prefix}{parent_command}{ctx.command} {ctx.command.signature}```"
             )
             await ctx.send(embed=embed)
             return

--- a/bot/exts/evergreen/timed.py
+++ b/bot/exts/evergreen/timed.py
@@ -21,7 +21,9 @@ class TimedCommands(commands.Cog):
         """Time the command execution of a command."""
         new_ctx = await self.create_execution_context(ctx, command)
 
-        if not new_ctx.command:
+        ctx.subcontext = new_ctx
+
+        if not ctx.subcontext.command:
             help_command = f"{ctx.prefix}help"
             error = f"The command you are trying to time doesn't exist. Use `{help_command}` for a list of commands."
 


### PR DESCRIPTION
## Description
When a new execution context is created in the timed command it's now added as the `subcontext` attribute of the parent context. When the error handler deals with the error the context is set to the subcontext if available, else the normal context. This means the command displays correctly.


## Reasoning
It's been implemented this way since I believe it to be the cleanest and simplest way to do this. If this turns out not to be the case I'm more than happy to change the implementation to something more suitable.


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/16879430/114460174-574ffb00-9bd9-11eb-89b0-699a2182ed26.png)
After:
![image](https://user-images.githubusercontent.com/16879430/114460194-5fa83600-9bd9-11eb-9181-c16190306eab.png)


## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
