### PR TITLE
Fix issue matching regex

### DIFF
--- a/bot/exts/evergreen/issues.py
+++ b/bot/exts/evergreen/issues.py
@@ -52,7 +52,9 @@ MAXIMUM_ISSUES = 5
 
 # Regex used when looking for automatic linking in messages
 # regex101 of current regex https://regex101.com/r/V2ji8M/6
-AUTOMATIC_REGEX = re.compile(r"((?P<org>[a-zA-Z0-9][a-zA-Z0-9\-]{1,39})\/)?(?P<repo>[\w\-\.]{1,100})#(?P<number>[0-9]+)")
+AUTOMATIC_REGEX = re.compile(
+    r"((?P<org>[a-zA-Z0-9][a-zA-Z0-9\-]{1,39})\/)?(?P<repo>[\w\-\.]{1,100})#(?P<number>[0-9]+)"
+)
 
 
 @dataclass

--- a/bot/exts/evergreen/issues.py
+++ b/bot/exts/evergreen/issues.py
@@ -51,7 +51,8 @@ CODE_BLOCK_RE = re.compile(
 MAXIMUM_ISSUES = 5
 
 # Regex used when looking for automatic linking in messages
-AUTOMATIC_REGEX = re.compile(r"((?P<org>.+?)\/)?(?P<repo>.+?)#(?P<number>.+?)")
+# regex101 of current regex https://regex101.com/r/V2ji8M/6
+AUTOMATIC_REGEX = re.compile(r"((?P<org>[a-zA-Z0-9][a-zA-Z0-9\-]{1,39})\/)?(?P<repo>[\w\-\.]{1,100})#(?P<number>[0-9]+)")
 
 
 @dataclass


### PR DESCRIPTION
fixes it being unable to get issue numbers larger than 9
limits it somewhat length-wise and character-wise to the actual github limits

## Description
Changed the regex to match numbers at the end greedily
Changed the regex to only match allowed characters

## Additional Details
regex used: https://regex101.com/r/V2ji8M/6

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [ ] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
