### PR TITLE
feat: add ping command

### DIFF
--- a/bot/exts/evergreen/ping.py
+++ b/bot/exts/evergreen/ping.py
@@ -1,0 +1,27 @@
+from discord import Embed
+from discord.ext import commands
+
+from bot.constants import Colours
+
+
+class Ping(commands.Cog):
+    """Ping the bot to see its latency and state."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name="ping")
+    async def ping(self, ctx: commands.Context) -> None:
+        """Ping the bot to see its latency and state."""
+        embed = Embed(
+            title="Pong!",
+            colour=Colours.bright_green,
+            description=f"WS Latency: {round(self.bot.latency * 1000)}ms",
+        )
+
+        await ctx.send(embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    """Cog load."""
+    bot.add_cog(Ping(bot))

--- a/bot/exts/evergreen/ping.py
+++ b/bot/exts/evergreen/ping.py
@@ -14,7 +14,7 @@ class Ping(commands.Cog):
     async def ping(self, ctx: commands.Context) -> None:
         """Ping the bot to see its latency and state."""
         embed = Embed(
-            title="Pong!",
+            title=":ping_pong: Pong!",
             colour=Colours.bright_green,
             description=f"WS Latency: {round(self.bot.latency * 1000)}ms",
         )

--- a/bot/exts/evergreen/ping.py
+++ b/bot/exts/evergreen/ping.py
@@ -16,7 +16,7 @@ class Ping(commands.Cog):
         embed = Embed(
             title=":ping_pong: Pong!",
             colour=Colours.bright_green,
-            description=f"WS Latency: {round(self.bot.latency * 1000)}ms",
+            description=f"Gateway Latency: {round(self.bot.latency * 1000)}ms",
         )
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
## Relevant Issues
No github issues, but the relevant conversation in pydis/dev-contrib is around here https://discord.com/channels/267624335836053506/635950537262759947/831533475760832603


## Description
A simple command that sends an embed showing the bot's websocket latency. It is simple as was discussed; it has no need to be complex, just provide basic information and more importantly show that the bot is online.


## Screenshots
![image](https://user-images.githubusercontent.com/16879430/114572794-b6f8e580-9c6f-11eb-8fbd-650821e9d4ed.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
