### PR TITLE
Fix Latex Cog Bug

### DIFF
--- a/bot/exts/evergreen/latex.py
+++ b/bot/exts/evergreen/latex.py
@@ -8,7 +8,6 @@ from io import BytesIO
 
 import discord
 import matplotlib.pyplot as plt
-from matplotlib import figure
 from discord.ext import commands
 from matplotlib import figure
 


### PR DESCRIPTION
## Description
Switched from `matplotlib.pyplot.figure` to `matplotlib.figure.Figure`.
Memory cleared manually with `del` and `gc.collect()`.
Cooldown added to the `.latex` command


## Reasoning
`matplotlib.pyplot.figure` isn't properly reference counted.
With these changes in place, memory usage doesn't increase without bound, plateaus out at ~110MB.

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
