### PR TITLE
feat: Use discord.PartialEmoji instead of discord.Emoji in the .emoji command

### DIFF
--- a/bot/exts/evergreen/emoji.py
+++ b/bot/exts/evergreen/emoji.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-from discord import Color, Embed, Emoji
+from discord import Color, Embed, PartialEmoji
 from discord.ext import commands
 
 from bot.constants import Colours, ERROR_REPLIES
@@ -71,7 +71,7 @@ class Emojis(commands.Cog):
         return embed, msg
 
     @commands.group(name="emoji", invoke_without_command=True)
-    async def emoji_group(self, ctx: commands.Context, emoji: Optional[Emoji]) -> None:
+    async def emoji_group(self, ctx: commands.Context, emoji: Optional[PartialEmoji]) -> None:
         """A group of commands related to emojis."""
         if emoji is not None:
             await ctx.invoke(self.info_command, emoji)
@@ -103,7 +103,7 @@ class Emojis(commands.Cog):
         await LinePaginator.paginate(lines=msg, ctx=ctx, embed=embed)
 
     @emoji_group.command(name="info", aliases=("i",))
-    async def info_command(self, ctx: commands.Context, emoji: Emoji) -> None:
+    async def info_command(self, ctx: commands.Context, emoji: PartialEmoji) -> None:
         """Returns relevant information about a Discord Emoji."""
         emoji_information = Embed(
             title=f"Emoji Information: {emoji.name}",


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
No relevant issues as this was discussed in `#dev-contrib`.

## Description
<!-- Describe how you've implemented your changes. -->
Instead of using `discord.Emoji` for the `.emoji`, I changed it to `discord.PartialEmoji` as the `PartialEmoji` has all the attributes the `.emoji` command uses.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
The current `.emoji` command doesn't currently allow emojis that the bot cannot see, and this PR changes so that any custom emoji can be used with this command.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
Before:
![before-image](https://cdn.discordapp.com/attachments/635950537262759947/832282584536842270/unknown.png)
After:
![after-image](https://user-images.githubusercontent.com/78174417/114904902-593ad980-9de6-11eb-82d6-7f3bbf00d689.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
