### PR TITLE
Suppress Links In Certain Commands

### DIFF
--- a/bot/exts/easter/egg_decorating.py
+++ b/bot/exts/easter/egg_decorating.py
@@ -10,6 +10,8 @@ import discord
 from PIL import Image
 from discord.ext import commands
 
+from bot.utils import helpers
+
 log = logging.getLogger(__name__)
 
 with open(Path("bot/resources/evergreen/html_colours.json"), encoding="utf8") as f:
@@ -65,7 +67,7 @@ class EggDecorating(commands.Cog):
             if value:
                 colours[idx] = discord.Colour(value)
             else:
-                invalid.append(colour)
+                invalid.append(helpers.suppress_links(colour))
 
         if len(invalid) > 1:
             return await ctx.send(f"Sorry, I don't know these colours: {' '.join(invalid)}")

--- a/bot/exts/evergreen/catify.py
+++ b/bot/exts/evergreen/catify.py
@@ -6,6 +6,7 @@ from discord import AllowedMentions, Embed, Forbidden
 from discord.ext import commands
 
 from bot.constants import Cats, Colours, NEGATIVE_REPLIES
+from bot.utils import helpers
 
 
 class Catify(commands.Cog):
@@ -74,7 +75,7 @@ class Catify(commands.Cog):
                 else:
                     string_list.insert(random.randint(0, len(string_list)), random.choice(Cats.cats))
 
-            text = " ".join(string_list)
+            text = helpers.suppress_links(" ".join(string_list))
             await ctx.send(
                 f">>> {text}",
                 allowed_mentions=AllowedMentions.none()

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -11,6 +11,7 @@ from discord.ext.commands import BadArgument, Bot, Cog, Context, MessageConverte
 
 from bot import utils
 from bot.constants import Client, Colours, Emojis
+from bot.utils import helpers
 
 log = logging.getLogger(__name__)
 
@@ -83,6 +84,7 @@ class Fun(Cog):
         if embed is not None:
             embed = Fun._convert_embed(conversion_func, embed)
         converted_text = conversion_func(text)
+        converted_text = helpers.suppress_links(converted_text)
         # Don't put >>> if only embed present
         if converted_text:
             converted_text = f">>> {converted_text.lstrip('> ')}"
@@ -101,6 +103,7 @@ class Fun(Cog):
         if embed is not None:
             embed = Fun._convert_embed(conversion_func, embed)
         converted_text = conversion_func(text)
+        converted_text = helpers.suppress_links(converted_text)
         # Don't put >>> if only embed present
         if converted_text:
             converted_text = f">>> {converted_text.lstrip('> ')}"

--- a/bot/utils/helpers.py
+++ b/bot/utils/helpers.py
@@ -1,0 +1,8 @@
+import re
+
+
+def suppress_links(message: str) -> str:
+    """Accepts a message that may contain links, suppresses them, and returns them."""
+    for link in set(re.findall(r"https?://[^\s]+", message, re.IGNORECASE)):
+        message = message.replace(link, f"<{link}>")
+    return message


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #703


## Description
<!-- Describe how you've implemented your changes. -->
I've added a helper that does a regex search through a given string, looks for `http` or `https`, and surrounds that with `<>`. I've called it in places I could find where the bot tries to echo part of, or the full user input back to the user.


## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Regex seemed like the most simple way to deal with finding links. This solution does not take into account that an already escaped link will end up with weird extra brackets around it, but that didn't seem to matter much.


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
