### PR TITLE
fix: remove () from list of safe filename chars

### DIFF
--- a/bot/exts/evergreen/avatar_modification/avatar_modify.py
+++ b/bot/exts/evergreen/avatar_modification/avatar_modify.py
@@ -40,7 +40,7 @@ async def in_executor(func: t.Callable, *args) -> t.Any:
 
 def file_safe_name(effect: str, display_name: str) -> str:
     """Returns a file safe filename based on the given effect and display name."""
-    valid_filename_chars = f"-_.() {string.ascii_letters}{string.digits}"
+    valid_filename_chars = f"-_. {string.ascii_letters}{string.digits}"
 
     file_name = FILENAME_STRING.format(effect=effect, author=display_name)
 


### PR DESCRIPTION
## Relevant Issues
Closes #712 

## Description
Removed `()` from the allowed filename characters since they cause issues in Discord with the file showing outside of the embed.

Before; 
![image](https://user-images.githubusercontent.com/16879430/116725828-622ccd00-a9da-11eb-8a89-3fd8930299e7.png)
After:
![image](https://user-images.githubusercontent.com/16879430/116725864-6fe25280-a9da-11eb-9619-fc93561f1b9b.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this tempelate?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
