### PR TITLE
Fix the spelling mistake in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@ Issues can be skipped with explicit core dev approval, but you have to link the 
 <!-- Replace [ ] with [x] to mark items as done. -->
 
 - [ ] Join the [**Python Discord Community**](https://discord.gg/python)?
-- [ ] Read all the comments in this tempelate?
+- [ ] Read all the comments in this template?
 - [ ] Ensure there is an issue open, or link relevant discord discussions?
 - [ ] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Fixed a spelling mistake in the PR template (tempelate -> template). Was discussed [here](https://discordapp.com/channels/267624335836053506/635950537262759947/837756009992028180).

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this tempelate <- this was the mistake
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
