### PR TITLE
Add a 5 second cooldown per user to .catify

### DIFF
--- a/bot/exts/evergreen/catify.py
+++ b/bot/exts/evergreen/catify.py
@@ -16,6 +16,7 @@ class Catify(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=["ᓚᘏᗢify", "ᓚᘏᗢ"])
+    @commands.cooldown(1, 5, commands.BucketType.user)
     async def catify(self, ctx: commands.Context, *, text: Optional[str]) -> None:
         """
         Convert the provided text into a cat themed sentence by interspercing cats throughout text.


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->
Discussed [here](https://discordapp.com/channels/267624335836053506/635950537262759947/839515870937088052).

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This PR adds a 1 use every 5 seconds cooldown per user to the `.catify` command to avoid spamming it.

## Screenshots
![](https://cdn.discordapp.com/attachments/809618457741099058/839523677003317298/unknown.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
