### PR TITLE
Fix the .mosaic command check that is missing a `not`

### DIFF
--- a/bot/exts/evergreen/avatar_modification/avatar_modify.py
+++ b/bot/exts/evergreen/avatar_modification/avatar_modify.py
@@ -322,7 +322,7 @@ class AvatarModify(commands.Cog):
                 await ctx.send(f"{Emojis.cross_mark} Could not get member info.")
                 return
 
-            if 1 <= squares <= MAX_SQUARES:
+            if not 1 <= squares <= MAX_SQUARES:
                 raise commands.BadArgument(f"Squares must be a positive number less than or equal to {MAX_SQUARES:,}.")
 
             sqrt = math.sqrt(squares)


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Fixes the check on the `.mosaic` command, which is missing a `not`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
