### PR TITLE
Latex: temporarily disable loading of the cog

### DIFF
--- a/bot/exts/evergreen/latex.py
+++ b/bot/exts/evergreen/latex.py
@@ -91,4 +91,9 @@ class Latex(commands.Cog):
 
 def setup(bot: commands.Bot) -> None:
     """Load the Latex Cog."""
+    # As we have resource issues on this cog,
+    # we have it currently disabled while we fix it.
+    import logging
+    logging.info("Latex cog is currently disabled. It won't be loaded.")
+    return
     bot.add_cog(Latex(bot))


### PR DESCRIPTION
As we are currently working on restricting resources on the latex cog, this commit will prevent it from loading.

It will be reverted once solved.