### PR TITLE
fix: Send the right help message for `.src help`

### DIFF
--- a/bot/exts/evergreen/source.py
+++ b/bot/exts/evergreen/source.py
@@ -33,7 +33,8 @@ class BotSource(commands.Cog):
         Raise BadArgument if `source_item` is a dynamically-created object (e.g. via internal eval).
         """
         if isinstance(source_item, commands.Command):
-            src = source_item.callback.__code__
+            callback = inspect.unwrap(source_item.callback)
+            src = callback.__code__
             filename = src.co_filename
         else:
             src = type(source_item)
@@ -64,12 +65,8 @@ class BotSource(commands.Cog):
         url, location, first_line = self.get_source_link(source_object)
 
         if isinstance(source_object, commands.Command):
-            if source_object.cog_name == "Help":
-                title = "Help Command"
-                description = source_object.__doc__.splitlines()[1]
-            else:
-                description = source_object.short_doc
-                title = f"Command: {source_object.qualified_name}"
+            description = source_object.short_doc
+            title = f"Command: {source_object.qualified_name}"
         else:
             title = f"Cog: {source_object.qualified_name}"
             description = source_object.description.splitlines()[0]


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->

Currently, when you do `.source help`, it sends the description of [`bot.command.Command`](https://github.com/python-discord/bot/blob/main/bot/command.py#L4-L11), instead of the actual help command. This is because of this line:

https://github.com/python-discord/bot/blob/67934bd582ae5a6fac459c02ba3fa6c17d085d1a/bot/exts/info/source.py#L112

Since our help command is just a regular command, I removed the check to see if the source item is a help command.

## Screenshots
Before:
![](https://user-images.githubusercontent.com/78174417/118412876-6576b880-b66a-11eb-8251-1b4fd0ff74e7.png)
After:
![](https://user-images.githubusercontent.com/78174417/118412884-732c3e00-b66a-11eb-88a0-5818e14520fc.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
