### PR TITLE
fix: Handle a KeyError when using .quiz stop

### DIFF
--- a/bot/exts/evergreen/trivia_quiz.py
+++ b/bot/exts/evergreen/trivia_quiz.py
@@ -465,22 +465,24 @@ class TriviaQuiz(commands.Cog):
 
         Note: Only mods or the owner of the quiz can stop it.
         """
-        if self.game_status[ctx.channel.id] is True:
-            # Check if the author is the game starter or a moderator.
-            if ctx.author == self.game_owners[ctx.channel.id] or any(
-                Roles.moderator == role.id for role in ctx.author.roles
-            ):
+        try:
+            if self.game_status[ctx.channel.id]:
+                # Check if the author is the game starter or a moderator.
+                if ctx.author == self.game_owners[ctx.channel.id] or any(
+                    Roles.moderator == role.id for role in ctx.author.roles
+                ):
+                    self.game_status[ctx.channel.id] = False
+                    del self.game_owners[ctx.channel.id]
+                    self.game_player_scores[ctx.channel.id] = {}
 
-                await ctx.send("Quiz stopped.")
-                await self.declare_winner(ctx.channel, self.game_player_scores[ctx.channel.id])
+                    await ctx.send("Quiz stopped.")
+                    await self.declare_winner(ctx.channel, self.game_player_scores[ctx.channel.id])
 
-                self.game_status[ctx.channel.id] = False
-                del self.game_owners[ctx.channel.id]
-                self.game_player_scores[ctx.channel.id] = {}
-
+                else:
+                    await ctx.send(f"{ctx.author.mention}, you are not authorised to stop this game :ghost:!")
             else:
-                await ctx.send(f"{ctx.author.mention}, you are not authorised to stop this game :ghost:!")
-        else:
+                await ctx.send("No quiz running.")
+        except KeyError:
             await ctx.send("No quiz running.")
 
     @quiz_game.command(name="leaderboard")


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->
Closes #739 

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This PR handles a `KeyError` in a race condition for `.quiz stop`. Just a `try/except`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
