### PR TITLE
Forward some status dog codes to status cat instead

### DIFF
--- a/bot/exts/evergreen/status_codes.py
+++ b/bot/exts/evergreen/status_codes.py
@@ -52,6 +52,11 @@ class HTTPStatusCodes(commands.Cog):
     @http_status_group.command(name="dog")
     async def http_dog(self, ctx: commands.Context, code: int) -> None:
         """Sends an embed with an image of a dog, portraying the status code."""
+        # These codes aren't server-friendly.
+        if code in (304, 422):
+            await self.http_cat(ctx, code)
+            return
+
         embed = discord.Embed(title=f"**Status: {code}**")
         url = HTTP_DOG_URL.format(code=code)
 


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
These status dog codes aren't server-friendly, so we use status cat instead.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
