### PR TITLE
Change to unless-stopped restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,17 @@
 version: "3.7"
+
+x-restart-policy: &restart_policy
+  restart: unless-stopped
+
 services:
   sir-lancebot:
+    << : *restart_policy
     build:
       context: .
       dockerfile: Dockerfile
     container_name: sir-lancebot
     init: true
 
-    restart: always
     depends_on:
       - redis
 
@@ -20,6 +24,7 @@ services:
       - .:/bot
 
   redis:
+    << : *restart_policy
     image: redis:latest
     ports:
       - "127.0.0.1:6379:6379"


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Since we use the same port for redis on all out projects, having this always restart causes conflicts for people starting up docker and wanting to use redis for any other project.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
