### PR TITLE
embed displays draw condition on show command

### DIFF
--- a/bot/exts/evergreen/tic_tac_toe.py
+++ b/bot/exts/evergreen/tic_tac_toe.py
@@ -320,7 +320,7 @@ class TicTacToe(Cog):
 
         embed = discord.Embed(
             title=f"Match #{game_id} Game Board",
-            description=f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
+            description=f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}" if game.draw else f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
         )
         await ctx.send(embed=embed)
 

--- a/bot/exts/evergreen/tic_tac_toe.py
+++ b/bot/exts/evergreen/tic_tac_toe.py
@@ -319,7 +319,7 @@ class TicTacToe(Cog):
         game = self.games[game_id - 1]
 
         if game.draw:
-            description = f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}"
+            description = f"{game.players[0]} vs {game.players[1]} (draw)\n\n{game.format_board()}"
         else:
             description = f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
 

--- a/bot/exts/evergreen/tic_tac_toe.py
+++ b/bot/exts/evergreen/tic_tac_toe.py
@@ -318,13 +318,15 @@ class TicTacToe(Cog):
             return
         game = self.games[game_id - 1]
 
+        if game.draw:
+            description = f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}"
+        else:
+            description = f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
+
         embed = discord.Embed(
             title=f"Match #{game_id} Game Board",
-            if game.draw:
-                description = f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}"
-            else:
-                description = f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
-        )
+            description=description,
+)
         await ctx.send(embed=embed)
 
 

--- a/bot/exts/evergreen/tic_tac_toe.py
+++ b/bot/exts/evergreen/tic_tac_toe.py
@@ -320,7 +320,10 @@ class TicTacToe(Cog):
 
         embed = discord.Embed(
             title=f"Match #{game_id} Game Board",
-            description=f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}" if game.draw else f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
+            if game.draw:
+                description = f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}"
+            else:
+                description = f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"
         )
         await ctx.send(embed=embed)
 

--- a/bot/exts/evergreen/tic_tac_toe.py
+++ b/bot/exts/evergreen/tic_tac_toe.py
@@ -326,7 +326,7 @@ class TicTacToe(Cog):
         embed = discord.Embed(
             title=f"Match #{game_id} Game Board",
             description=description,
-)
+        )
         await ctx.send(embed=embed)
 
 


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #771 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
In tic_tac_toe.py, I changed the description being returned in the embed for the show_tic_tac_toe function from - 

`description=f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"`

to - 

`description=f"{game.winner} vs {game.loser} (draw)\n\n{game.format_board()}" if game.draw else f"{game.winner} :trophy: vs {game.loser}\n\n{game.format_board()}"`

where it checks for the draw condition of the respective game before evaluating the value of embed.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
