### PR TITLE
Allow commands in code jam team channels

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -127,6 +127,7 @@ class Categories(NamedTuple):
     media = 799054581991997460
     staff = 364918151625965579
 
+codejam_categories_name = "Code Jam"  # Name of the codejam team categories
 
 class Client(NamedTuple):
     name = "Sir Lancebot"

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -75,6 +75,11 @@ def in_whitelist_check(
         log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they are in a whitelisted category.")
         return True
 
+    category = getattr(ctx.channel, "category", None)
+    if category and category.name == constants.codejam_categories_name:
+        log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they are in a codejam team channel.")
+        return True
+
     # Only check the roles whitelist if we have one and ensure the author's roles attribute returns
     # an iterable to prevent breakage in DM channels (for if we ever decide to enable commands there).
     if roles and any(r.id in roles for r in getattr(ctx.author, "roles", ())):


### PR DESCRIPTION
## Relevant Issues

> It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.

Uh, well, actually technically I didn't do that, sorry 😢 

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I added permissions for members to run sir-lancebot commands in their codejam team channels. I added a constant with the name of the category, and added the check to the `in_whitelist` check function.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [no] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
