### PR TITLE
Correct an off-by-one bug due to bisect.bisect()

### DIFF
--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -74,7 +74,8 @@ class LoveCalculator(Cog):
         # We need the -1 due to how bisect returns the point
         # see the documentation for further detail
         # https://docs.python.org/3/library/bisect.html#bisect.bisect
-        index = bisect.bisect(LOVE_DATA, (love_percent,)) - 1
+        love_threshold = [threshold for threshold, _ in LOVE_DATA] 
+        index = bisect.bisect(love_threshold, love_percent) - 1
         # We already have the nearest "fit" love level
         # We only need the dict, so we can ditch the first element
         _, data = LOVE_DATA[index]

--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -74,7 +74,7 @@ class LoveCalculator(Cog):
         # We need the -1 due to how bisect returns the point
         # see the documentation for further detail
         # https://docs.python.org/3/library/bisect.html#bisect.bisect
-        love_threshold = [threshold for threshold, _ in LOVE_DATA] 
+        love_threshold = [threshold for threshold, _ in LOVE_DATA]
         index = bisect.bisect(love_threshold, love_percent) - 1
         # We already have the nearest "fit" love level
         # We only need the dict, so we can ditch the first element


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #784 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I removed the `-1` from the quote index calculation at <https://github.com/python-discord/sir-lancebot/blob/3218ff7d59c9db211039414b8c84ea098fd784d6/bot/exts/valentines/lovecalculator.py#L75> This means the command `[p]love` (`[p]` refers to Lancebot's prefix) will now return the correct quote for `love_percent = 0` edge-case, and scores in the range [96, 100] will now correctly use the 100 quote from `bot/resources/valentines/love_matches.json` instead of the 95 quote.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
