### PR TITLE
Make user affirm their pr follows guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@ Issues can be skipped with explicit core dev approval, but you have to link the 
 - [ ] Join the [**Python Discord Community**](https://discord.gg/python)?
 - [ ] Read all the comments in this template?
 - [ ] Ensure there is an issue open, or link relevant discord discussions?
-- [ ] Read the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
+- [ ] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
The contributing guidelines also contain a part which requires contributions to follow the open source license. 
This requires the user to agree that they do follow said guidelines when making a pr.
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [ ] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
