### PR TITLE
Only send articles to user - Closes Issue#828

### DIFF
--- a/bot/exts/evergreen/realpython.py
+++ b/bot/exts/evergreen/realpython.py
@@ -53,10 +53,15 @@ class RealPython(commands.Cog):
             await ctx.send(embed=no_articles)
             return
 
+        if len(articles) == 1:
+            article_description = "Here is the result:"
+        else:
+            article_description = f"Here are the top {len(articles)} results:"
+
         article_embed = Embed(
             title="Search results - Real Python",
             url=SEARCH_URL.format(user_search=quote_plus(user_search)),
-            description=f"Here are the top {len(articles)} results:",
+            description=article_description,
             color=Colours.orange,
         )
 

--- a/bot/exts/evergreen/realpython.py
+++ b/bot/exts/evergreen/realpython.py
@@ -33,7 +33,7 @@ class RealPython(commands.Cog):
     @commands.cooldown(1, 10, commands.cooldowns.BucketType.user)
     async def realpython(self, ctx: commands.Context, *, user_search: str) -> None:
         """Send 5 articles that match the user's search terms."""
-        params = {"q": user_search, "limit": 5}
+        params = {"q": user_search, "limit": 5, "kind": "article"}
         async with self.bot.http_session.get(url=API_ROOT, params=params) as response:
             if response.status != 200:
                 logger.error(
@@ -56,7 +56,7 @@ class RealPython(commands.Cog):
         article_embed = Embed(
             title="Search results - Real Python",
             url=SEARCH_URL.format(user_search=quote_plus(user_search)),
-            description="Here are the top 5 results:",
+            description=f"Here are the top {max(5, len(articles))} results:",
             color=Colours.orange,
         )
 

--- a/bot/exts/evergreen/realpython.py
+++ b/bot/exts/evergreen/realpython.py
@@ -56,7 +56,7 @@ class RealPython(commands.Cog):
         article_embed = Embed(
             title="Search results - Real Python",
             url=SEARCH_URL.format(user_search=quote_plus(user_search)),
-            description=f"Here are the top {max(5, len(articles))} results:",
+            description=f"Here are the top {len(articles)} results:",
             color=Colours.orange,
         )
 


### PR DESCRIPTION
Added the "kind": "article" parameter to the API request. This should only return articles to the user instead of courses, lessons or quizzes.

Also updated the "Here are the top x results" message to handle a variable amount of articles.
[Ticket: python-discord#828]

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #828

## Description
<!-- Describe what changes you made, and how you've implemented them. -->

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
