### PR TITLE
Use permissions_for over permissions_in

### DIFF
--- a/bot/exts/evergreen/bookmark.py
+++ b/bot/exts/evergreen/bookmark.py
@@ -103,7 +103,7 @@ class Bookmark(commands.Cog):
             target_message = ctx.message.reference.resolved
 
         # Prevent users from bookmarking a message in a channel they don't have access to
-        permissions = ctx.author.permissions_in(target_message.channel)
+        permissions = target_message.channel.permissions_for(ctx.author)
         if not permissions.read_messages:
             log.info(f"{ctx.author} tried to bookmark a message in #{target_message.channel} but has no permissions.")
             embed = discord.Embed(

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -197,11 +197,13 @@ class Fun(Cog):
 
         msg = await Fun._get_discord_message(ctx, text)
         # Ensure the user has read permissions for the channel the message is in
-        if isinstance(msg, Message) and ctx.author.permissions_in(msg.channel).read_messages:
-            text = msg.clean_content
-            # Take first embed because we can't send multiple embeds
-            if msg.embeds:
-                embed = msg.embeds[0]
+        if isinstance(msg, Message):
+            permissions = msg.channel.permissions_for(ctx.author)
+            if permissions.read_messages:
+                text = msg.clean_content
+                # Take first embed because we can't send multiple embeds
+                if msg.embeds:
+                    embed = msg.embeds[0]
 
         return (text, embed)
 


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #837 Closes #840

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
`discord.Member.permissions_in()` was removed in d.py 2.0 in favour of using `discord.Channel.permissions_for` everywhere.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
