### PR TITLE
Add support to query AoC results in respect of days and stars

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -88,6 +88,7 @@ class AdventOfCode:
     ignored_days = environ.get("AOC_IGNORED_DAYS", "").split(",")
     leaderboard_displayed_members = 10
     leaderboard_cache_expiry_seconds = 1800
+    max_dayandstar_results = 15
     year = int(environ.get("AOC_YEAR", datetime.utcnow().year))
     role_id = int(environ.get("AOC_ROLE_ID", 518565788744024082))
 


### PR DESCRIPTION
## Relevant Issues
Closes #321 
## Description
From now on the AoC leaderboard command accepts a total of 2 optional arguments a day and star string (eg.: 1-2, for the second star of the first day) and a number of results they would like to see, with a total maximum of 15. (Default is 10)
(The reason I used csharp syntax highlighting is because it surprisingly fits the results quite well)
![alt text](https://cdn.discordapp.com/attachments/857588537845874689/884474637365411920/Kepernyofoto_2021-09-06_-_18.26.14.png)
## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
