### PR TITLE
Added Hanukka command in November month.

### DIFF
--- a/bot/exts/holidays/hanukkah/hanukkah_embed.py
+++ b/bot/exts/holidays/hanukkah/hanukkah_embed.py
@@ -37,7 +37,7 @@ class HanukkahEmbed(commands.Cog):
                 hanukkah_dates.append(date)
         return hanukkah_dates
 
-    @in_month(Month.DECEMBER)
+    @in_month(Month.NOVEMBER, Month.DECEMBER)
     @commands.command(name="hanukkah", aliases=("chanukah",))
     async def hanukkah_festival(self, ctx: commands.Context) -> None:
         """Tells you about the Hanukkah Festivaltime of festival, festival day, etc)."""


### PR DESCRIPTION
This is a solution for the #862 issue, which says the Hanukka holiday can also be in November and not only in December.

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #862 


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I added the Hanukka command in November month, by adding Month.NOVEMBER to the in_month decorator.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
