### PR TITLE
Make the discord.py datetimes offset-naive

### DIFF
--- a/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
+++ b/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
@@ -52,10 +52,10 @@ class HacktoberIssues(commands.Cog):
     async def get_issues(self, ctx: commands.Context, option: str) -> Optional[dict]:
         """Get a list of the python issues with the label 'hacktoberfest' from the Github api."""
         if option == "beginner":
-            if (ctx.message.created_at - self.cache_timer_beginner).seconds <= 60:
+            if (ctx.message.created_at.replace(tzinfo=None) - self.cache_timer_beginner).seconds <= 60:
                 log.debug("using cache")
                 return self.cache_beginner
-        elif (ctx.message.created_at - self.cache_timer_normal).seconds <= 60:
+        elif (ctx.message.created_at.replace(tzinfo=None) - self.cache_timer_normal).seconds <= 60:
             log.debug("using cache")
             return self.cache_normal
 

--- a/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
+++ b/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
@@ -88,10 +88,10 @@ class HacktoberIssues(commands.Cog):
 
             if option == "beginner":
                 self.cache_beginner = data
-                self.cache_timer_beginner = ctx.message.created_at
+                self.cache_timer_beginner = ctx.message.created_at.replace(tzinfo=None)
             else:
                 self.cache_normal = data
-                self.cache_timer_normal = ctx.message.created_at
+                self.cache_timer_normal = ctx.message.created_at.replace(tzinfo=None)
 
             return data
 

--- a/bot/exts/utilities/emoji.py
+++ b/bot/exts/utilities/emoji.py
@@ -107,8 +107,8 @@ class Emojis(commands.Cog):
             title=f"Emoji Information: {emoji.name}",
             description=textwrap.dedent(f"""
                 **Name:** {emoji.name}
-                **Created:** {time_since(emoji.created_at, precision="hours")}
-                **Date:** {datetime.strftime(emoji.created_at, "%d/%m/%Y")}
+                **Created:** {time_since(emoji.created_at.replace(tzinfo=None), precision="hours")}
+                **Date:** {datetime.strftime(emoji.created_at.replace(tzinfo=None), "%d/%m/%Y")}
                 **ID:** {emoji.id}
             """),
             color=Color.blurple(),


### PR DESCRIPTION
You know the drill, due to discord.py 2.0a0 datetimes are now offset-aware, breaking some code.

Closes python-discord/sir-lancebot#875

