### PR TITLE
Fix error with `.help`

### DIFF
--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -288,7 +288,7 @@ class HelpSession:
         paginator = LinePaginator(prefix="", suffix="", max_lines=self._max_lines)
 
         # show signature if query is a command
-        if isinstance(self.query, commands.Command):
+        if isinstance(self.query, Command):
             await self._add_command_signature(paginator)
 
         if isinstance(self.query, Cog):
@@ -332,7 +332,7 @@ class HelpSession:
         if isinstance(self.query, Cog):
             grouped = (("**Commands:**", self.query.commands),)
 
-        elif isinstance(self.query, commands.Command):
+        elif isinstance(self.query, Command):
             grouped = (("**Subcommands:**", self.query.commands),)
 
         # otherwise sort and organise all commands into categories
@@ -394,7 +394,7 @@ class HelpSession:
                 return []
             strikeout = "~~"
 
-        if isinstance(self.query, commands.Command):
+        if isinstance(self.query, Command):
             prefix = ""
         else:
             prefix = constants.Client.prefix
@@ -410,7 +410,7 @@ class HelpSession:
         """Returns an Embed with the requested page formatted within."""
         embed = Embed()
 
-        if isinstance(self.query, (commands.Command, Cog)) and page_number > 0:
+        if isinstance(self.query, (Command, Cog)) and page_number > 0:
             title = f'Command Help | "{self.query.name}"'
         else:
             title = self.title

--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -49,7 +49,7 @@ class HelpQueryNotFound(ValueError):
     query, where keys are the possible matched command names and values are the likeness match scores.
     """
 
-    def __init__(self, arg: str, possible_matches: dict = None):
+    def __init__(self, arg: str, possible_matches: list[str] = None):
         super().__init__(arg)
         self.possible_matches = possible_matches
 
@@ -161,7 +161,7 @@ class HelpSession:
 
         result = process.extract(query, choices, score_cutoff=90)
 
-        raise HelpQueryNotFound(f'Query "{query}" not found.', dict(result))
+        raise HelpQueryNotFound(f'Query "{query}" not found.', [choice[0] for choice in result])
 
     async def timeout(self, seconds: int = 30) -> None:
         """Waits for a set number of seconds, then stops the help session."""
@@ -515,7 +515,7 @@ class Help(DiscordCog):
             embed.title = str(error)
 
             if error.possible_matches:
-                matches = "\n".join(error.possible_matches.keys())
+                matches = "\n".join(error.possible_matches)
                 embed.description = f"**Did you mean:**\n`{matches}`"
 
             await ctx.send(embed=embed)


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #863 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Fixed the traceback caused by `process.extract` returning 3 items when `dict()` can only take 2.

Ended up changing the data-structure of the argument sent to `HelpQueryNotFound to `list[str]` since only the keys where ever used anyway.

Also noticed there was some inconsistency within the file in regards to `commands.Command` so fixed that too.

NB: I couldn't figure out how to get the bot running with dpy2.0 so this is currently untested, but *should* work.
EDIT: Have since managed to get it to run, and this does work as intended.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?

