### PR TITLE
Allow everyone to use the `.bm` command everywhere

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -280,12 +280,12 @@ if Client.month_override is not None:
 
 
 class Roles(NamedTuple):
+    owner = 267627879762755584
     admin = int(environ.get("BOT_ADMIN_ROLE_ID", 267628507062992896))
     moderator = 267629731250176001
-    owner = 267627879762755584
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     core_developers = 587606783669829632
-    everyone = 267624335836053506
+    everyone = int(environ.get("BOT_GUILD", 267624335836053506)) 
 
 
 class Tokens(NamedTuple):

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -285,6 +285,7 @@ class Roles(NamedTuple):
     owner = 267627879762755584
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     core_developers = 587606783669829632
+    everyone = 267624335836053506
 
 
 class Tokens(NamedTuple):

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -285,7 +285,7 @@ class Roles(NamedTuple):
     moderator = 267629731250176001
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     core_developers = 587606783669829632
-    everyone = int(environ.get("BOT_GUILD", 267624335836053506)) 
+    everyone = int(environ.get("BOT_GUILD", 267624335836053506))
 
 
 class Tokens(NamedTuple):

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.constants import Categories, Colours, ERROR_REPLIES, Icons, WHITELISTED_CHANNELS
+from bot.constants import Colours, ERROR_REPLIES, Icons, Roles
 from bot.utils.converters import WrappedMessageConverter
 from bot.utils.decorators import whitelist_override
 
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 # Number of seconds to wait for other users to bookmark the same message
 TIMEOUT = 120
 BOOKMARK_EMOJI = "📌"
-WHITELISTED_CATEGORIES = (Categories.help_in_use,)
 
 
 class Bookmark(commands.Cog):
@@ -87,8 +86,8 @@ class Bookmark(commands.Cog):
         await message.add_reaction(BOOKMARK_EMOJI)
         return message
 
-    @whitelist_override(channels=WHITELISTED_CHANNELS, categories=WHITELISTED_CATEGORIES)
     @commands.command(name="bookmark", aliases=("bm", "pin"))
+    @whitelist_override(roles=(Roles.everyone,))
     async def bookmark(
         self,
         ctx: commands.Context,


### PR DESCRIPTION
## Relevant Issues
Closes #827

## Description
Allowed the `.bm` command to be used everywhere by using our whitelist overrider.

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
