### PR TITLE
Allow `.bm` command to be used everywhere

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -285,6 +285,7 @@ class Roles(NamedTuple):
     owner = 267627879762755584
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     core_developers = 587606783669829632
+    everyone = 267624335836053506
 
 
 class Tokens(NamedTuple):

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.constants import Categories, Colours, ERROR_REPLIES, Icons, WHITELISTED_CHANNELS
+from bot.constants import Colours, ERROR_REPLIES, Icons
 from bot.utils.converters import WrappedMessageConverter
 from bot.utils.decorators import whitelist_override
 
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 # Number of seconds to wait for other users to bookmark the same message
 TIMEOUT = 120
 BOOKMARK_EMOJI = "📌"
-WHITELISTED_CATEGORIES = (Categories.help_in_use,)
 
 
 class Bookmark(commands.Cog):
@@ -87,8 +86,8 @@ class Bookmark(commands.Cog):
         await message.add_reaction(BOOKMARK_EMOJI)
         return message
 
-    @whitelist_override(channels=WHITELISTED_CHANNELS, categories=WHITELISTED_CATEGORIES)
     @commands.command(name="bookmark", aliases=("bm", "pin"))
+    @whitelist_override(every=True)
     async def bookmark(
         self,
         ctx: commands.Context,

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -40,6 +40,7 @@ def in_whitelist_check(
     channels: Container[int] = (),
     categories: Container[int] = (),
     roles: Container[int] = (),
+    every: bool = False,
     redirect: Optional[int] = constants.Channels.community_bot_commands,
     fail_silently: bool = False,
 ) -> bool:
@@ -51,6 +52,8 @@ def in_whitelist_check(
     - `channels`: a container with channel ids for whitelisted channels
     - `categories`: a container with category ids for whitelisted categories
     - `roles`: a container with with role ids for whitelisted roles
+    - `every`: a boolean value that, when set to True, allows the command
+               to be used everywhere by everyone
 
     If the command was invoked in a context that was not whitelisted, the member is either
     redirected to the `redirect` channel that was passed (default: #bot-commands) or simply
@@ -67,24 +70,43 @@ def in_whitelist_check(
         # categories, it's probably not wise to rely on its category in any case.
         channels = tuple(channels) + (redirect,)
 
+    if every:
+        log.trace(
+            f"{ctx.author} may use the `{ctx.command.name}` command "
+            f"as it is completely whitelisted by every."
+        )
+        return True
+
     if channels and ctx.channel.id in channels:
-        log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they are in a whitelisted channel.")
+        log.trace(
+            f"{ctx.author} may use the `{ctx.command.name}` command "
+            f"as they are in a whitelisted channel."
+        )
         return True
 
     # Only check the category id if we have a category whitelist and the channel has a `category_id`
     if categories and hasattr(ctx.channel, "category_id") and ctx.channel.category_id in categories:
-        log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they are in a whitelisted category.")
+        log.trace(
+            f"{ctx.author} may use the `{ctx.command.name}` command "
+            f"as they are in a whitelisted category."
+        )
         return True
 
     category = getattr(ctx.channel, "category", None)
     if category and category.name == constants.codejam_categories_name:
-        log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they are in a codejam team channel.")
+        log.trace(
+            f"{ctx.author} may use the `{ctx.command.name}` command "
+            f"as they are in a codejam team channel."
+        )
         return True
 
     # Only check the roles whitelist if we have one and ensure the author's roles attribute returns
     # an iterable to prevent breakage in DM channels (for if we ever decide to enable commands there).
     if roles and any(r.id in roles for r in getattr(ctx.author, "roles", ())):
-        log.trace(f"{ctx.author} may use the `{ctx.command.name}` command as they have a whitelisted role.")
+        log.trace(
+            f"{ctx.author} may use the `{ctx.command.name}` command "
+            f"as they have a whitelisted role."
+        )
         return True
 
     log.trace(f"{ctx.author} may not use the `{ctx.command.name}` command within this context.")

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -280,7 +280,10 @@ def whitelist_check(**default_kwargs: Container[int]) -> Callable[[Context], boo
     return predicate
 
 
-def whitelist_override(bypass_defaults: bool = False, **kwargs: Container[int]) -> Callable:
+def whitelist_override(
+        bypass_defaults: bool = False,
+        **kwargs: Union[Container[int], Optional[int], bool]
+) -> Callable:
     """
     Override global whitelist context, with the kwargs specified.
 


### PR DESCRIPTION
## Relevant Issues
Closes #827

## Description
Allowed the `.bm` command to be used everywhere by using the everyone role in the whitelist overrider.

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
