### PR TITLE
Change pascal's triangle image

### DIFF
--- a/bot/resources/fun/trivia_quiz.json
+++ b/bot/resources/fun/trivia_quiz.json
@@ -440,7 +440,7 @@
     {
       "id": 229,
       "question": "What is this triangle called?",
-      "img_url": "https://cdn.askpython.com/wp-content/uploads/2020/07/Pascals-triangle.png",
+      "img_url": "https://wikimedia.org/api/rest_v1/media/math/render/png/23050fcb53d6083d9e42043bebf2863fa9746043",
       "answer": ["Pascal's triangle", "Pascal"]
     },
     {


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #888 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I change the image associated to the pascal's triangle question via editing the `quiz_trivia.json` file.

Image shows before and after:
![image](https://user-images.githubusercontent.com/47674925/135713796-1b089022-a04d-4fad-9e60-26234ad08bfc.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
