### PR TITLE
Ignore all bot messages for spooky react

### DIFF
--- a/bot/exts/holidays/halloween/spookyreact.py
+++ b/bot/exts/holidays/halloween/spookyreact.py
@@ -47,12 +47,12 @@ class SpookyReact(Cog):
         Short-circuit helper check.
 
         Return True if:
-          * author is the bot
+          * author is a bot
           * prefix is not None
         """
-        # Check for self reaction
-        if message.author == self.bot.user:
-            log.debug(f"Ignoring reactions on self message. Message ID: {message.id}")
+        # Check if message author is a bot
+        if message.author.bot:
+            log.debug(f"Ignoring reactions on bot message. Message ID: {message.id}")
             return True
 
         # Check for command invocation


### PR DESCRIPTION
Spooky reactions are now limited to users. The example below was previously possible, but won't happen anymore:
<img width="223" alt="Screenshot 2021-10-03 at 15 35 28" src="https://user-images.githubusercontent.com/65498475/135755934-0cad961e-9f0f-4b88-bea7-1af5e0671cef.png">

The bot previously only ignored its own messages, but now ignores messages from all bots. Even though we love our bots, they simply aren't supposed to be a part of this Halloween tradition. Sorry Xith!