### PR TITLE
Candy collection: fix positional arg being passed as kword

### DIFF
--- a/bot/exts/holidays/halloween/candy_collection.py
+++ b/bot/exts/holidays/halloween/candy_collection.py
@@ -134,7 +134,7 @@ class CandyCollection(commands.Cog):
     @property
     def hacktober_channel(self) -> discord.TextChannel:
         """Get #hacktoberbot channel from its ID."""
-        return self.bot.get_channel(id=Channels.community_bot_commands)
+        return self.bot.get_channel(Channels.community_bot_commands)
 
     @staticmethod
     async def send_spook_msg(


### PR DESCRIPTION

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->


<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Approved by myself

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Removed the `id` keyword. This caused a `TypeError` to be raised, as the `id` argument could only be used as a positional argument and not by keyword. 

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
