### PR TITLE
Replace usage of bot.command_prefix with constants.Client.prefix

### DIFF
--- a/bot/exts/fun/trivia_quiz.py
+++ b/bot/exts/fun/trivia_quiz.py
@@ -16,7 +16,7 @@ from discord.ext import commands, tasks
 from rapidfuzz import fuzz
 
 from bot.bot import Bot
-from bot.constants import Colours, NEGATIVE_REPLIES, Roles
+from bot.constants import Client, Colours, NEGATIVE_REPLIES, Roles
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +332,7 @@ class TriviaQuiz(commands.Cog):
         if self.game_status[ctx.channel.id]:
             await ctx.send(
                 "Game is already running... "
-                f"do `{self.bot.command_prefix}quiz stop`"
+                f"do `{Client.prefix}quiz stop`"
             )
             return
 

--- a/bot/exts/holidays/halloween/spookynamerate.py
+++ b/bot/exts/holidays/halloween/spookynamerate.py
@@ -143,7 +143,7 @@ class SpookyNameRate(Cog):
             if data["author"] == ctx.author.id:
                 await ctx.send(
                     "But you have already added an entry! Type "
-                    f"`{self.bot.command_prefix}spookynamerate "
+                    f"`{Client.prefix}spookynamerate "
                     "delete` to delete it, and then you can add it again"
                 )
                 return
@@ -185,7 +185,7 @@ class SpookyNameRate(Cog):
                 return
 
         await ctx.send(
-            f"But you don't have an entry... :eyes: Type `{self.bot.command_prefix}spookynamerate add your entry`"
+            f"But you don't have an entry... :eyes: Type `{Client.prefix}spookynamerate add your entry`"
         )
 
     @Cog.listener()
@@ -225,7 +225,7 @@ class SpookyNameRate(Cog):
                 "Okkey... Welcome to the **Spooky Name Rate Game**! It's a relatively simple game.\n"
                 f"Everyday, a random name will be sent in <#{Channels.community_bot_commands}> "
                 "and you need to try and spookify it!\nRegister your name using "
-                f"`{self.bot.command_prefix}spookynamerate add spookified name`"
+                f"`{Client.prefix}spookynamerate add spookified name`"
             )
 
             await self.data.set("first_time", False)


### PR DESCRIPTION
## Relevant Issues
Fixes an issue where you got messages like `Game is already running... do <function when_mentioned_or.<locals>.inner at 0x7fe4412a8ee0>quiz stop` because `command_prefix` isn't always a string https://discordpy.readthedocs.io/en/stable/ext/commands/api.html?highlight=bot%20command_prefix#discord.ext.commands.Bot.command_prefix



## Description
<!-- Describe what changes you made, and how you've implemented them. -->

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
