### PR TITLE
Fix hacktoberfest cog not dealing with issues with empty bodies 

### DIFF
--- a/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
+++ b/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
@@ -100,7 +100,8 @@ class HacktoberIssues(commands.Cog):
         """Format the issue data into a embed."""
         title = issue["title"]
         issue_url = issue["url"].replace("api.", "").replace("/repos/", "/")
-        body = issue["body"]
+        # issues can have empty bodies, which in that case GitHub doesn't include the key in the API response
+        body = issue.get("body", "")
         labels = [label["name"] for label in issue["labels"]]
 
         embed = discord.Embed(title=title)


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes GH-907
Solves SIR-LANCEBOT-6R

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Issues can have empty bodies, in this case GitHub doesn't include the key in the API response

Used a .get() in order to fill in the issue body.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
