### PR TITLE
Fix bugs in `.issue` command & add aliases

### DIFF
--- a/bot/exts/utilities/issues.py
+++ b/bot/exts/utilities/issues.py
@@ -185,7 +185,7 @@ class Issues(commands.Cog):
         return resp
 
     @whitelist_override(channels=WHITELISTED_CHANNELS, categories=WHITELISTED_CATEGORIES)
-    @commands.command(aliases=("pr",))
+    @commands.command(aliases=("issues", "pr", "prs"))
     async def issue(
         self,
         ctx: commands.Context,
@@ -197,14 +197,23 @@ class Issues(commands.Cog):
         # Remove duplicates
         numbers = set(numbers)
 
-        if len(numbers) > MAXIMUM_ISSUES:
-            embed = discord.Embed(
+        err_message = None
+        if not numbers:
+            err_message = "You must have at least one issue/PR!"
+
+        elif len(numbers) > MAXIMUM_ISSUES:
+            err_message = f"Too many issues/PRs! (maximum of {MAXIMUM_ISSUES})"
+
+        # If there's an error with command invocation then send an error embed
+        if err_message is not None:
+            err_embed = discord.Embed(
                 title=random.choice(ERROR_REPLIES),
                 color=Colours.soft_red,
-                description=f"Too many issues/PRs! (maximum of {MAXIMUM_ISSUES})"
+                description=err_message
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=err_embed)
             await invoke_help_command(ctx)
+            return
 
         results = [await self.fetch_issues(number, repository, user) for number in numbers]
         await ctx.send(embed=self.format_embed(results, user, repository))


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
N/A, approved by @Akarys internally:
![image](https://user-images.githubusercontent.com/47674925/137625302-4f0a7407-cd78-47d6-b575-600b63eb3c0d.png)

## Description
<!-- Describe what changes you made, and how you've implemented them. -->

- Command now requires at least one issue/PR
- Command no longer continues to send issues/PRs when there's too many listed in the invocation
- Added plural aliases to the command (`.issues` and `.prs`)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
