### PR TITLE
Global Leaderboard

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -89,8 +89,8 @@ class Bot(commands.Bot):
             )
             return
 
-        current_points = await _leaderboard_cache.get(user.id) or 0
-        current_points_today = await _per_day_leaderboard.get(user.id) or 0
+        current_points = await _leaderboard_cache.get(user.id, 0)
+        current_points_today = await _per_day_leaderboard.get(user.id, 0)
         new_points_today = current_points_today + points
 
         if new_points_today > MAX_PER_GAME_PER_DAY_POINTS:
@@ -197,9 +197,7 @@ class Bot(commands.Bot):
         devlog = self.get_channel(constants.Channels.devlog)
 
         if not devlog:
-            log.info(
-                f"Fetching devlog channel as it wasn't found in the cache (ID: {constants.Channels.devlog})"
-            )
+            log.info(f"Fetching devlog channel as it wasn't found in the cache (ID: {constants.Channels.devlog})")
             try:
                 devlog = await self.fetch_channel(constants.Channels.devlog)
             except discord.HTTPException as discord_exc:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,8 +1,8 @@
 import asyncio
+import datetime
 import logging
 import socket
 from contextlib import suppress
-from datetime import datetime, timedelta
 from typing import Optional
 
 import discord
@@ -12,7 +12,6 @@ from discord import DiscordException, Embed, Forbidden, Thread
 from discord.ext import commands
 from discord.ext.commands import Cog, when_mentioned_or
 from discord.ext.tasks import loop
-from discord.utils import sleep_until
 
 from bot import constants
 
@@ -48,20 +47,12 @@ class Bot(commands.Bot):
         # Mapping for the main games leaderboard
         # The key holds the name of the discord Cog and the value is the redis cache object
         # for that specific game leaderboard
-        self.games_leaderboard: dict[str, tuple[RedisCache, ...]] = dict()
+        self.games_leaderboard: dict[str, tuple[RedisCache, ...]] = {}
         self.auto_per_day_leaderboard_clear.start()
 
-    @loop()
+    @loop(time=datetime.time.min)
     async def auto_per_day_leaderboard_clear(self) -> None:
         """Loop for clearing the per day leaderboard redis cache at UTC midnight."""
-        # once d.py get support for `time` parameter in loop decorator,
-        # this can be removed and the loop can use the `time=datetime.time.min` parameter
-        now = datetime.utcnow()
-        tomorrow = now + timedelta(days=1)
-        midnight_tomorrow = tomorrow.replace(hour=0, minute=0, second=0)
-
-        await sleep_until(midnight_tomorrow)
-
         for _, per_day_lb in self.games_leaderboard.values():
             await per_day_lb.clear()
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -77,10 +77,17 @@ class Bot(commands.Bot):
         Increment points for a user in the leaderboard for game `cog` by `points`.
 
         If max points for today are hit for that particular game cog, then set today's points to the max
-        points and add the difference of the(before today points and max possible points for a day to the
-        overall points for the user.
+        points and add the difference of today's points and maximum daily possible points to the overall
+        points for the user.
         """
-        _leaderboard_cache, _per_day_leaderboard = self.games_leaderboard.get(cog.qualified_name)
+        try:
+            _leaderboard_cache, _per_day_leaderboard = self.games_leaderboard[cog.qualified_name]
+        except KeyError:
+            log.error(
+                f"No leaderboards found for cog {cog.qualified_name}. Make sure to run `ensure_leaderboard` "
+                f"before using this utility function."
+            )
+            return
 
         current_points = await _leaderboard_cache.get(user.id) or 0
         current_points_today = await _per_day_leaderboard.get(user.id) or 0

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -123,11 +123,11 @@ class Leaderboard(commands.Cog):
 
         lines = []
         for index, (member_id, score) in enumerate(top_ten, start=1):
-            mention = f"<@{member_id}>"
-            rank = self.ordinal_number(index)
+            rank = self.get_rank(index)
             buffer = 4 if index >= 4 else len(rank)+1
-            formatted_rank = format(rank, f"\u2800<{buffer}")
-            lines.append(f"{formatted_rank}{score:\u2800<4}— {mention}")
+            formatted_rank = format(rank, f"\N{BRAILLE PATTERN BLANK}<{buffer}")
+            formatted_score = format(score, "\N{BRAILLE PATTERN BLANK}<4")
+            lines.append(f"{formatted_rank}{formatted_score}— <@{member_id}>")
 
         embed = discord.Embed(
             title="Top 10",

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -1,0 +1,59 @@
+from collections import Counter
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from bot.bot import Bot
+from bot.constants import Colours
+
+
+class Leaderboard(commands.Cog):
+    """Get info about the bot's ping and uptime."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @staticmethod
+    def ordinal_number(n: int) -> str:
+        suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
+        if 11 <= (n % 100) <= 13:
+            suffix = "th"
+        return str(n) + suffix
+
+    @commands.command(aliases=("lb",))
+    async def leaderboard(self, ctx: commands.Context) -> None:
+        """Get the current top 10."""
+        leaderboard = Counter()
+
+        for cached_leaderboard in self.bot.games_leaderboard.values():
+            _leaderboard: dict[int, int] = await cached_leaderboard.to_dict()
+            leaderboard += Counter(_leaderboard)
+
+        top_ten = leaderboard.most_common(10)
+
+        lines = []
+        for index, (member_id, score) in enumerate(top_ten, start=1):
+            rank = format(self.ordinal_number(index), " >4")
+            score = format(score, " >4")
+            mention = f"<@{member_id}>"
+            lines.append(f"`{rank} |  {score} |` {mention}")
+
+        board_formatted = "\n".join(lines) if lines else "(no entries yet)"
+        description = f"`Rank | Score |` Member\n{board_formatted}"
+
+        embed = discord.Embed(
+            title="Top 10",
+            description=description,
+            colour=Colours.orange,
+            timestamp=datetime.utcnow(),
+        )
+        embed.set_thumbnail(
+            url="https://cdn.discordapp.com/emojis/902160691509723208.png?size=96"
+        )
+        await ctx.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    """Load the Leaderboard cog."""
+    bot.add_cog(Leaderboard(bot))

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -2,6 +2,7 @@ from collections import Counter
 from datetime import datetime
 
 import discord
+from async_rediscache import RedisCache
 from discord.ext import commands
 
 from bot.bot import Bot
@@ -9,26 +10,29 @@ from bot.constants import Colours
 
 
 class Leaderboard(commands.Cog):
-    """Get info about the bot's ping and uptime."""
+    """Cog for getting game leaderboards."""
 
     def __init__(self, bot: Bot):
         self.bot = bot
 
     @staticmethod
     def ordinal_number(n: int) -> str:
+        """Get the ordinal number for `n`."""
         suffix = ["th", "st", "nd", "rd", "th"][min(n % 10, 4)]
         if 11 <= (n % 100) <= 13:
             suffix = "th"
         return str(n) + suffix
 
-    @commands.command(aliases=("lb",))
-    async def leaderboard(self, ctx: commands.Context) -> None:
-        """Get the current top 10."""
-        leaderboard = Counter()
-
-        for cached_leaderboard in self.bot.games_leaderboard.values():
-            _leaderboard: dict[int, int] = await cached_leaderboard.to_dict()
-            leaderboard += Counter(_leaderboard)
+    async def make_leaderboard(self, cached_leaderboard: list[RedisCache]) -> discord.Embed:
+        """Make a discord embed for the current top 10 members in the cached leaderboard."""
+        if len(cached_leaderboard) == 1:
+            game_leaderboard = await cached_leaderboard[0].to_dict()
+            leaderboard = Counter(game_leaderboard)
+        else:
+            leaderboard = Counter()
+            for lb in cached_leaderboard:
+                game_leaderboard = await lb.to_dict()
+                leaderboard += Counter(game_leaderboard)
 
         top_ten = leaderboard.most_common(10)
 
@@ -51,6 +55,39 @@ class Leaderboard(commands.Cog):
         embed.set_thumbnail(
             url="https://cdn.discordapp.com/emojis/902160691509723208.png?size=96"
         )
+
+        return embed
+
+    @commands.group(aliases=("lb",), invoke_without_command=True)
+    async def leaderboard(self, ctx: commands.Context, game: str = None) -> None:
+        """Get overall leaderboard if not game specified, else leaderboard for that game."""
+        if ctx.invoked_subcommand:
+            return
+
+        if game:
+            leaderboards = self.bot.games_leaderboard.get(game)
+            await ctx.send(", ".join(self.bot.games_leaderboard.keys()))
+            if not leaderboards:
+                raise commands.BadArgument(f"Leaderboard for game {game} not found.")
+            leaderboard = [leaderboards[0]]
+        else:
+            leaderboard = [lb for lb, _ in self.bot.games_leaderboard.values()]
+
+        embed = await self.make_leaderboard(leaderboard)
+        await ctx.send(embed=embed)
+
+    @leaderboard.command(name="today", aliases=("t",))
+    async def per_day_leaderboard(self, ctx: commands.Context, game: str = None) -> None:
+        """Get today's overall leaderboard if not game specified, else leaderboard for that game."""
+        if game:
+            leaderboards = self.bot.games_leaderboard.get(game)
+            if not leaderboards:
+                raise commands.BadArgument(f"Leaderboard for game {game} not found.")
+            leaderboard = [leaderboards[1]]
+        else:
+            leaderboard = [lb for _, lb in self.bot.games_leaderboard.values()]
+
+        embed = await self.make_leaderboard(leaderboard)
         await ctx.send(embed=embed)
 
 

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -61,13 +61,13 @@ class ConfirmClear(ui.View):
 
     @ui.button(label="Confirm", style=ButtonStyle.green, row=0)
     async def confirm(self, _button: ui.Button, interaction: Interaction) -> None:
-        """Redeploy the specified service."""
-        for global_lb, _ in self.bot.games_leaderboard.values():
-            await global_lb.clear()
+        """Functionality ran when the clearing the total leaderboard has been approved.."""
+        for total_lb, _ in self.bot.games_leaderboard.values():
+            await total_lb.clear()
 
         log.info(f"The leaderboard was cleared by Member({self.authorization})")
         await interaction.response.send_message(
-            content=":white_check_mark: Cleared all game leaderboards.",
+            content=":white_check_mark: Cleared all total game leaderboards.",
             ephemeral=False
         )
 
@@ -75,7 +75,7 @@ class ConfirmClear(ui.View):
 
     @ui.button(label="Cancel", style=ButtonStyle.grey, row=0)
     async def cancel(self, _button: ui.Button, interaction: Interaction) -> None:
-        """Logic for if the deployment is not approved."""
+        """Functionality ran when the clearing the total leaderboard has been denied."""
         await interaction.response.send_message(
             content=":x: Clearing cache aborted!",
             ephemeral=False,
@@ -113,8 +113,7 @@ class Leaderboard(commands.Cog):
         else:
             leaderboard = Counter()
             for lb in cached_leaderboard:
-                game_leaderboard = await lb.to_dict()
-                leaderboard += Counter(game_leaderboard)
+                leaderboard += Counter(await lb.to_dict())
 
         top_ten = leaderboard.most_common(10)
         try:
@@ -183,7 +182,7 @@ class Leaderboard(commands.Cog):
         confirmation = ConfirmClear(ctx.author.id, self.bot)
 
         msg = await ctx.send(
-            ":warning: THIS WILL IRREVOCABLY CLEAR THE LEADERBOARD. ARE YOU SURE?",
+            ":warning: THIS WILL IRREVOCABLY CLEAR THE TOTAL LEADERBOARD. ARE YOU SURE?",
             view=confirmation,
         )
 

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -139,7 +139,7 @@ class Leaderboard(commands.Cog):
         embed.set_footer(
             text=(
                 f"Page 1/{math.ceil(len(sorted_lb) / 10)}  |"
-                f"  Your rank: {author_rank}/{len(sorted_lb)}"
+                f"  |  Your rank: {author_rank}/{len(sorted_lb)}" if author_rank else ""
             )
         )
         embed.set_thumbnail(url=DUCKY_COINS_THUMBNAIL)

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -18,6 +18,25 @@ DUCKY_COINS_THUMBNAIL = (
 )
 
 
+class ParentCogConvertor(commands.Converter):
+    """Return the parent cog name for the argument."""
+
+    @staticmethod
+    async def convert(ctx: commands.Context, argument: str) -> str:
+        """Return the parent cog name for the argument."""
+        cog: commands.Cog = ctx.bot.get_cog(argument)
+        if cog:
+            return cog.qualified_name
+
+        cmd: commands.Command = ctx.bot.get_command(argument)
+        if cmd:
+            return cmd.cog_name
+
+        raise commands.BadArgument(
+            f"Unable to convert `{argument}` to valid command or Cog."
+        )
+
+
 class ConfirmClear(ui.View):
     """A confirmation view for clearing the leaderboard caches."""
 
@@ -112,14 +131,13 @@ class Leaderboard(commands.Cog):
         return embed
 
     @commands.group(aliases=("lb",), invoke_without_command=True)
-    async def leaderboard(self, ctx: commands.Context, game: str = None) -> None:
+    async def leaderboard(self, ctx: commands.Context, game: ParentCogConvertor = None) -> None:
         """Get overall leaderboard if not game specified, else leaderboard for that game."""
         if ctx.invoked_subcommand:
             return
 
         if game:
             leaderboards = self.bot.games_leaderboard.get(game)
-            await ctx.send(", ".join(self.bot.games_leaderboard.keys()))
             if not leaderboards:
                 raise commands.BadArgument(f"Leaderboard for game {game} not found.")
             leaderboard = [leaderboards[0]]
@@ -130,7 +148,7 @@ class Leaderboard(commands.Cog):
         await ctx.send(embed=embed)
 
     @leaderboard.command(name="today", aliases=("t",))
-    async def per_day_leaderboard(self, ctx: commands.Context, game: str = None) -> None:
+    async def per_day_leaderboard(self, ctx: commands.Context, game: ParentCogConvertor = None) -> None:
         """Get today's overall leaderboard if not game specified, else leaderboard for that game."""
         if game:
             leaderboards = self.bot.games_leaderboard.get(game)

--- a/bot/exts/core/leaderboard.py
+++ b/bot/exts/core/leaderboard.py
@@ -62,8 +62,8 @@ class ConfirmClear(ui.View):
     @ui.button(label="Confirm", style=ButtonStyle.green, row=0)
     async def confirm(self, _button: ui.Button, interaction: Interaction) -> None:
         """Redeploy the specified service."""
-        for _, per_day_lb in self.bot.games_leaderboard.values():
-            await per_day_lb.clear()
+        for global_lb, _ in self.bot.games_leaderboard.values():
+            await global_lb.clear()
 
         log.info(f"The leaderboard was cleared by Member({self.authorization})")
         await interaction.response.send_message(

--- a/bot/exts/fun/coinflip.py
+++ b/bot/exts/fun/coinflip.py
@@ -27,6 +27,10 @@ class CoinSide(commands.Converter):
 class CoinFlip(commands.Cog):
     """Cog for the CoinFlip command."""
 
+    def __init__(self, bot: Bot) -> None:
+        self.bot = bot
+        self.bot.ensure_leaderboard(self)
+
     @commands.command(name="coinflip", aliases=("flip", "coin", "cf"))
     async def coinflip_command(self, ctx: commands.Context, side: CoinSide = None) -> None:
         """
@@ -42,6 +46,7 @@ class CoinFlip(commands.Cog):
             return
 
         if side == flipped_side:
+            await self.bot.change_points(self, ctx.author, 10)
             message += f"You guessed correctly! {Emojis.lemon_hyperpleased}"
         else:
             message += f"You guessed incorrectly. {Emojis.lemon_pensive}"
@@ -50,4 +55,4 @@ class CoinFlip(commands.Cog):
 
 def setup(bot: Bot) -> None:
     """Loads the coinflip cog."""
-    bot.add_cog(CoinFlip())
+    bot.add_cog(CoinFlip(bot))

--- a/bot/exts/fun/coinflip.py
+++ b/bot/exts/fun/coinflip.py
@@ -46,7 +46,7 @@ class CoinFlip(commands.Cog):
             return
 
         if side == flipped_side:
-            await self.bot.change_points(self, ctx.author, 10)
+            await self.bot.increment_points(self, ctx.author, 10)
             message += f"You guessed correctly! {Emojis.lemon_hyperpleased}"
         else:
             message += f"You guessed incorrectly. {Emojis.lemon_pensive}"


### PR DESCRIPTION
## Relevant Issues
Closes #627 


## Description
This implements the global leaderboard command, it is basically a leaderboard for all the games together, if you win the coinflip, you get some points, the points you get in the trivia quiz gets added here, etc.

This feature makes use of Redis Caches (two per game) to store the game leaderboards, one being the overall leaderboard (total) and the second being the per day leaderboard which gets cleared every day at midnight UTC through a discord task loop. The overall/total leaderboard would have an additional suffix `-total` at the end of its cache so that it doesn't clash with the per-day leaderboard. The leaderboards are currently based on the cog qualified name, I will be adding support for getting it with the command name. The leaderboards can be initialised for a cog with the help of the `Bot` method `ensure_leaderboard` which takes in the Cog object you want to make the leaderboard for. 

Currently, I have only added a helper function `increment_points`, if there is a need for a util function to decrement points, it can be done.

To interact with the leaderboard as a user, I have added a leaderboard cog that allows you to view per day leaderboards (overall and for a specific game) and the overall leaderboard (overall and for a specific game). It also adds an additional administrator command which can be used to clear the leaderboard if needed.

I have currently taken the coin thumbnail image as a discord image link, it would be updated once @Sn4u 's design gets finalised and merged into the branding repository.

##### Clear
![Screenshot from 2021-10-27 06-41-45](https://user-images.githubusercontent.com/69356296/138983295-3e3c8601-9c8d-40c9-8155-2f917f81777d.png)

#### Leaderboard (old - my preference)
![Screenshot from 2021-10-27 06-42-35](https://user-images.githubusercontent.com/69356296/138983349-1eaf2763-59df-44fc-ae4d-d0824c49614a.png)

#### Leaderboard (new - 1c9c495 - others in dev-contrib)
![Screenshot from 2021-11-05 17-27-51](https://user-images.githubusercontent.com/69356296/140507064-8d5d279a-590b-43b6-afcd-aef265625c04.png)


#### ToDo
- [ ] Add leaderboard support to all game/fun cogs. This would be done at a later stage once the core functionality gets reviewed. I have added an example (coinflip command) so the reviewers can test the code easily and know how it works.


## Did you:
- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
