### PR TITLE
Candy Game: Ignore reactions to bot messages when adding candies

### DIFF
--- a/bot/exts/holidays/halloween/candy_collection.py
+++ b/bot/exts/holidays/halloween/candy_collection.py
@@ -83,6 +83,11 @@ class CandyCollection(commands.Cog):
         # if its not a candy or skull, and it is one of 10 most recent messages,
         # proceed to add a skull/candy with higher chance
         if str(reaction.emoji) not in (EMOJIS["SKULL"], EMOJIS["CANDY"]):
+            # Ensure the reaction is not for a bot's message so users can't spam
+            # reaction buttons like in .help to get candies.
+            if message.author.bot:
+                return
+
             recent_message_ids = map(
                 lambda m: m.id,
                 await self.hacktober_channel.history(limit=10).flatten()


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
[Approved by core dev to PR without issue](https://discord.com/channels/267624335836053506/635950537262759947/903279888495157329)

## Description
<!-- Describe what changes you made, and how you've implemented them. -->

Check whether a reaction is for a bot message when adding candies upon reactions. Previously you could use bot's reaction buttons which would trigger `on_reaction_add` and have a high chance of getting candies (or skulls). It can easily be abused to spam reactions, which apparently doesn't trigger an auto-mute like spamming messages do, AFAIK.

It can be tested using commands that has bot reaction buttons like `.help` or `.ttt`.

## Additional thoughts

I don't really like the fact that reaction triggers have a higher chance to get candies (even though sure reactions are rarer than messages). There's still a way to spam candies, but normal users are quite unlikely to figure out how. But anyway, it's just a game *and* it's just for the month of october. Not like a million dollar worth of crypto investment or such.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
