### PR TITLE
Limit user reactions on embed pagination

### DIFF
--- a/bot/exts/utilities/wikipedia.py
+++ b/bot/exts/utilities/wikipedia.py
@@ -86,9 +86,7 @@ class WikipediaSearch(commands.Cog):
             )
             embed.set_thumbnail(url=WIKI_THUMBNAIL)
             embed.timestamp = datetime.utcnow()
-            await LinePaginator.paginate(
-                contents, ctx, embed, restrict_to_user=ctx.author
-            )
+            await LinePaginator.paginate(contents, ctx, embed, restrict_to_user=ctx.author)
         else:
             await ctx.send(
                 "Sorry, we could not find a wikipedia article using that search term."

--- a/bot/exts/utilities/wikipedia.py
+++ b/bot/exts/utilities/wikipedia.py
@@ -87,7 +87,7 @@ class WikipediaSearch(commands.Cog):
             embed.set_thumbnail(url=WIKI_THUMBNAIL)
             embed.timestamp = datetime.utcnow()
             await LinePaginator.paginate(
-                contents, ctx, embed
+                contents, ctx, embed, restrict_to_user=ctx.author
             )
         else:
             await ctx.send(


### PR DESCRIPTION

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->
Close #933 
<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I added `restrict_to_user=ctx.author` to wikipedia.py. Limits user reactions to prevent non-author from removing message by adding user restriction to paginator.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
