### PR TITLE
Handle `.wtf` command without query

### DIFF
--- a/bot/exts/utilities/wtf_python.py
+++ b/bot/exts/utilities/wtf_python.py
@@ -79,7 +79,7 @@ class WTFPython(commands.Cog):
         return match if certainty > MINIMUM_CERTAINTY else None
 
     @commands.command(aliases=("wtf", "WTF"))
-    async def wtf_python(self, ctx: commands.Context, *, query: str = None) -> None:
+    async def wtf_python(self, ctx: commands.Context, *, query: Optional[str] = None) -> None:
         """
         Search WTF Python repository.
 

--- a/bot/exts/utilities/wtf_python.py
+++ b/bot/exts/utilities/wtf_python.py
@@ -91,7 +91,7 @@ class WTFPython(commands.Cog):
             no_query_embed = Embed(
                 title="WTF Python?!",
                 colour=constants.Colours.dark_green,
-                description="A repository filled with suprising snippets that can make you say WTF?!\n"
+                description="A repository filled with suprising snippets that can make you say WTF?!\n\n"
                 f"[Go to the Repository]({BASE_URL})"
             )
             logo = File(LOGO_PATH, filename="wtf_logo.jpg")

--- a/bot/exts/utilities/wtf_python.py
+++ b/bot/exts/utilities/wtf_python.py
@@ -79,7 +79,7 @@ class WTFPython(commands.Cog):
         return match if certainty > MINIMUM_CERTAINTY else None
 
     @commands.command(aliases=("wtf", "WTF"))
-    async def wtf_python(self, ctx: commands.Context, *, query: str) -> None:
+    async def wtf_python(self, ctx: commands.Context, *, query: str = None) -> None:
         """
         Search WTF Python repository.
 
@@ -87,7 +87,18 @@ class WTFPython(commands.Cog):
         Usage:
             --> .wtf wild imports
         """
-        if len(query) > 50:
+        if query is None:
+            no_query_embed = Embed(
+                title="WTF Python?!",
+                colour=constants.Colours.dark_green,
+                description="A repository filled with suprising snippets that can make you say WTF?! "
+                f"[Go to the Repository]({BASE_URL})"
+            )
+            logo = File(LOGO_PATH, filename="wtf_logo.jpg")
+            no_query_embed.set_thumbnail(url="attachment://wtf_logo.jpg")
+            await ctx.send(embed=no_query_embed, file=logo)
+            return
+        elif len(query) > 50:
             embed = Embed(
                 title=random.choice(constants.ERROR_REPLIES),
                 description=ERROR_MESSAGE,

--- a/bot/exts/utilities/wtf_python.py
+++ b/bot/exts/utilities/wtf_python.py
@@ -98,7 +98,8 @@ class WTFPython(commands.Cog):
             no_query_embed.set_thumbnail(url="attachment://wtf_logo.jpg")
             await ctx.send(embed=no_query_embed, file=logo)
             return
-        elif len(query) > 50:
+
+        if len(query) > 50:
             embed = Embed(
                 title=random.choice(constants.ERROR_REPLIES),
                 description=ERROR_MESSAGE,

--- a/bot/exts/utilities/wtf_python.py
+++ b/bot/exts/utilities/wtf_python.py
@@ -91,7 +91,7 @@ class WTFPython(commands.Cog):
             no_query_embed = Embed(
                 title="WTF Python?!",
                 colour=constants.Colours.dark_green,
-                description="A repository filled with suprising snippets that can make you say WTF?! "
+                description="A repository filled with suprising snippets that can make you say WTF?!\n"
                 f"[Go to the Repository]({BASE_URL})"
             )
             logo = File(LOGO_PATH, filename="wtf_logo.jpg")


### PR DESCRIPTION
-Added a default value to `query`, and if the value is None, send the
link to the repository in an embed.
-Modified the if / else statements to if / elif / else with the new
if statement to check if the value of `query` is None.

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes#938

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
-Added a default value to `query`, and if the value is None, send the
link to the repository in an embed.
-Modified the if / else statements to if / elif / else with the new
if statement to check if the value of `query` is None.
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
