### PR TITLE
Add option to get specific amount of articles

### DIFF
--- a/bot/exts/utilities/realpython.py
+++ b/bot/exts/utilities/realpython.py
@@ -1,5 +1,6 @@
 import logging
 from html import unescape
+from typing import Optional
 from urllib.parse import quote_plus
 
 from discord import Embed
@@ -7,7 +8,6 @@ from discord.ext import commands
 
 from bot.bot import Bot
 from bot.constants import Colours
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/bot/exts/utilities/realpython.py
+++ b/bot/exts/utilities/realpython.py
@@ -41,6 +41,7 @@ class RealPython(commands.Cog):
         if not 1 <= amount <= 5:
             await ctx.send("`amount` must be between 1 and 5 (inclusive).")
             return
+
         params = {"q": user_search, "limit": amount, "kind": "article"}
         async with self.bot.http_session.get(url=API_ROOT, params=params) as response:
             if response.status != 200:

--- a/bot/exts/utilities/realpython.py
+++ b/bot/exts/utilities/realpython.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 
 from bot.bot import Bot
 from bot.constants import Colours
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +32,16 @@ class RealPython(commands.Cog):
 
     @commands.command(aliases=["rp"])
     @commands.cooldown(1, 10, commands.cooldowns.BucketType.user)
-    async def realpython(self, ctx: commands.Context, *, user_search: str) -> None:
-        """Send 5 articles that match the user's search terms."""
-        params = {"q": user_search, "limit": 5, "kind": "article"}
+    async def realpython(self, ctx: commands.Context, amount: Optional[int] = 5, *, user_search: str) -> None:
+        """
+        Send `amount` articles that match the search terms (`user_search`).
+
+        `amount` must be between 1 and 5 (inclusive). If it's not, an error message is sent.
+        """
+        if not 1 <= amount <= 5:
+            await ctx.send("`amount` must be between 1 and 5 (inclusive).")
+            return
+        params = {"q": user_search, "limit": amount, "kind": "article"}
         async with self.bot.http_session.get(url=API_ROOT, params=params) as response:
             if response.status != 200:
                 logger.error(

--- a/bot/exts/utilities/wikipedia.py
+++ b/bot/exts/utilities/wikipedia.py
@@ -87,7 +87,7 @@ class WikipediaSearch(commands.Cog):
             embed.set_thumbnail(url=WIKI_THUMBNAIL)
             embed.timestamp = datetime.utcnow()
             await LinePaginator.paginate(
-                contents, ctx, embed, restrict_to_user=ctx.author
+                contents, ctx, embed
             )
         else:
             await ctx.send(

--- a/bot/exts/utilities/wikipedia.py
+++ b/bot/exts/utilities/wikipedia.py
@@ -87,7 +87,7 @@ class WikipediaSearch(commands.Cog):
             embed.set_thumbnail(url=WIKI_THUMBNAIL)
             embed.timestamp = datetime.utcnow()
             await LinePaginator.paginate(
-                contents, ctx, embed
+                contents, ctx, embed, restrict_to_user=ctx.author
             )
         else:
             await ctx.send(


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #940 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Now the `.rp` command has option to get specific amount of articles in between 1-5 (inclusive). I added new parameter to `.rp` which is `amount`. If no argument given when command is ran, the default value 5 will be used. If user tries to give negative, 0 or bigger than 5 , the bot will send a message saying "`amount must be between 1 and 5 (inclusive).`". 
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
