### PR TITLE
Fix Startup Crash Loop

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -6,13 +6,31 @@ except ModuleNotFoundError:
     pass
 
 import asyncio
+import logging
 import os
 from functools import partial, partialmethod
 
 import arrow
+import sentry_sdk
 from discord.ext import commands
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
 
 from bot import log, monkey_patches
+
+sentry_logging = LoggingIntegration(
+    level=logging.DEBUG,
+    event_level=logging.WARNING
+)
+
+sentry_sdk.init(
+    dsn=os.environ.get("BOT_SENTRY_DSN"),
+    integrations=[
+        sentry_logging,
+        RedisIntegration()
+    ],
+    release=f"sir-lancebot@{os.environ.get('GIT_SHA', 'foobar')}"
+)
 
 log.setup()
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,27 +1,9 @@
 import logging
 
-import sentry_sdk
-from sentry_sdk.integrations.logging import LoggingIntegration
-from sentry_sdk.integrations.redis import RedisIntegration
-
 from bot.bot import bot
-from bot.constants import Client, GIT_SHA, STAFF_ROLES, WHITELISTED_CHANNELS
+from bot.constants import Client, STAFF_ROLES, WHITELISTED_CHANNELS
 from bot.utils.decorators import whitelist_check
 from bot.utils.extensions import walk_extensions
-
-sentry_logging = LoggingIntegration(
-    level=logging.DEBUG,
-    event_level=logging.WARNING
-)
-
-sentry_sdk.init(
-    dsn=Client.sentry_dsn,
-    integrations=[
-        sentry_logging,
-        RedisIntegration()
-    ],
-    release=f"sir-lancebot@{GIT_SHA}"
-)
 
 log = logging.getLogger(__name__)
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -134,7 +134,6 @@ class Client(NamedTuple):
     guild = int(environ.get("BOT_GUILD", 267624335836053506))
     prefix = environ.get("PREFIX", ".")
     token = environ.get("BOT_TOKEN")
-    sentry_dsn = environ.get("BOT_SENTRY_DSN")
     debug = environ.get("BOT_DEBUG", "true").lower() == "true"
     github_bot_repo = "https://github.com/python-discord/sir-lancebot"
     # Override seasonal locks: 1 (January) to 12 (December)
@@ -347,8 +346,6 @@ WHITELISTED_CHANNELS = (
     Channels.voice_chat_0,
     Channels.voice_chat_1,
 )
-
-GIT_SHA = environ.get("GIT_SHA", "foobar")
 
 # Bot replies
 ERROR_REPLIES = [

--- a/bot/log.py
+++ b/bot/log.py
@@ -18,19 +18,22 @@ def setup() -> None:
 
     format_string = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
     log_format = logging.Formatter(format_string)
-
-    # Set up file logging
-    log_file = Path("logs/sir-lancebot.log")
-    log_file.parent.mkdir(exist_ok=True)
-
-    # File handler rotates logs every 5 MB
-    file_handler = logging.handlers.RotatingFileHandler(
-        log_file, maxBytes=5 * (2 ** 20), backupCount=10, encoding="utf-8",
-    )
-    file_handler.setFormatter(log_format)
-
     root_logger = logging.getLogger()
-    root_logger.addHandler(file_handler)
+
+    # Copied from constants file, which we can't import yet since loggers aren't instantiated
+    debug = os.environ.get("BOT_DEBUG", "true").lower() == "true"
+
+    if debug:
+        # Set up file logging
+        log_file = Path("logs/sir-lancebot.log")
+        log_file.parent.mkdir(exist_ok=True)
+
+        # File handler rotates logs every 5 MB
+        file_handler = logging.handlers.RotatingFileHandler(
+            log_file, maxBytes=5 * (2 ** 20), backupCount=10, encoding="utf-8",
+        )
+        file_handler.setFormatter(log_format)
+        root_logger.addHandler(file_handler)
 
     if "COLOREDLOGS_LEVEL_STYLES" not in os.environ:
         coloredlogs.DEFAULT_LEVEL_STYLES = {


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
The most recent changes to the logging setup were crashing the bot on startup in prod, as `/logs` was read-only. This PR prevents any file logs from being written in prod, since we don't use them anyways.

This PR also moves the sentry setup into the init, so we can catch any errors that happen before we get to main (such as the one behind this bug). It's not best practice for the `__init__` to have side-effects, but it really doesn't matter in this case.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
