### PR TITLE
minor: allow color command in dev-media

### DIFF
--- a/bot/exts/utilities/colour.py
+++ b/bot/exts/utilities/colour.py
@@ -11,8 +11,10 @@ import rapidfuzz
 from PIL import Image, ImageColor
 from discord.ext import commands
 
+from bot import constants
 from bot.bot import Bot
 from bot.exts.core.extensions import invoke_help_command
+from bot.utils.decorators import whitelist_override
 
 THUMBNAIL_SIZE = (80, 80)
 
@@ -78,6 +80,11 @@ class Colour(commands.Cog):
         await ctx.send(file=thumbnail_file, embed=colour_embed)
 
     @commands.group(aliases=("color",), invoke_without_command=True)
+    @whitelist_override(
+        channels=constants.WHITELISTED_CHANNELS,
+        roles=constants.STAFF_ROLES,
+        categories=[constants.Categories.development, constants.Categories.media]
+    )
     async def colour(self, ctx: commands.Context, *, colour_input: Optional[str] = None) -> None:
         """
         Create an embed that displays colour information.


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->
Context: https://discord.com/channels/267624335836053506/635950537262759947/909560534381252619

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Added decorator to allow bot in the dev and media categories. 
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?