### PR TITLE
Fix a grammatical mistake in the description of the `.spookify` command

### DIFF
--- a/bot/exts/avatar_modification/avatar_modify.py
+++ b/bot/exts/avatar_modification/avatar_modify.py
@@ -286,7 +286,7 @@ class AvatarModify(commands.Cog):
     @avatar_modify.command(
         aliases=("savatar", "spookify"),
         root_aliases=("spookyavatar", "spookify", "savatar"),
-        brief="Spookify an user's avatar."
+        brief="Spookify a user's avatar."
     )
     async def spookyavatar(self, ctx: commands.Context) -> None:
         """This "spookifies" the user's avatar, with a random *spooky* effect."""


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->

Discussion: [https://discord.com/channels/267624335836053506/635950537262759947/912443523029168168](url)

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This PR is simply to fix a grammatical mistake in the description ("brief") of the `.spookify` command on Sir Lancebot.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
