### PR TITLE
Aoc count timestamp

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -115,15 +115,11 @@ class AdventOfCode(commands.Cog):
         deltas = (dec_first - datetime_now for dec_first in (this_year, next_year))
         delta = min(delta for delta in deltas if delta >= timedelta())  # timedelta() gives 0 duration delta
 
-        # Add a finer timedelta if there's less than a day left
-        if delta.days == 0:
-            delta_str = f"approximately {delta.seconds // 3600} hours"
-        else:
-            delta_str = f"{delta.days} days"
+        next_aoc_timestamp = int((datetime_now + delta).timestamp())
 
         await ctx.send(
             "The Advent of Code event is not currently running. "
-            f"The next event will start in {delta_str}."
+            f"The next event will start <t:{next_aoc_timestamp}:R>."
         )
 
     @adventofcode_group.command(name="about", aliases=("ab", "info"), brief="Learn about Advent of Code")

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -100,32 +100,31 @@ class AdventOfCode(commands.Cog):
     @whitelist_override(channels=AOC_WHITELIST)
     async def aoc_countdown(self, ctx: commands.Context) -> None:
         """Return time left until next day."""
-        if not _helpers.is_in_advent():
-            datetime_now = arrow.now(_helpers.EST)
+        if _helpers.is_in_advent():
+            tomorrow, time_left = _helpers.time_left_to_est_midnight()
+            hours, minutes = time_left.seconds // 3600, time_left.seconds // 60 % 60
 
-            # Calculate the delta to this & next year's December 1st to see which one is closest and not in the past
-            this_year = arrow.get(datetime(datetime_now.year, 12, 1), _helpers.EST)
-            next_year = arrow.get(datetime(datetime_now.year + 1, 12, 1), _helpers.EST)
-            deltas = (dec_first - datetime_now for dec_first in (this_year, next_year))
-            delta = min(delta for delta in deltas if delta >= timedelta())  # timedelta() gives 0 duration delta
-
-            # Add a finer timedelta if there's less than a day left
-            if delta.days == 0:
-                delta_str = f"approximately {delta.seconds // 3600} hours"
-            else:
-                delta_str = f"{delta.days} days"
-
-            await ctx.send(
-                "The Advent of Code event is not currently running. "
-                f"The next event will start in {delta_str}."
-            )
+            await ctx.send(f"There are {hours} hours and {minutes} minutes left until day {tomorrow.day}.")
             return
 
-        tomorrow, time_left = _helpers.time_left_to_est_midnight()
+        datetime_now = arrow.now(_helpers.EST)
 
-        hours, minutes = time_left.seconds // 3600, time_left.seconds // 60 % 60
+        # Calculate the delta to this & next year's December 1st to see which one is closest and not in the past
+        this_year = arrow.get(datetime(datetime_now.year, 12, 1), _helpers.EST)
+        next_year = arrow.get(datetime(datetime_now.year + 1, 12, 1), _helpers.EST)
+        deltas = (dec_first - datetime_now for dec_first in (this_year, next_year))
+        delta = min(delta for delta in deltas if delta >= timedelta())  # timedelta() gives 0 duration delta
 
-        await ctx.send(f"There are {hours} hours and {minutes} minutes left until day {tomorrow.day}.")
+        # Add a finer timedelta if there's less than a day left
+        if delta.days == 0:
+            delta_str = f"approximately {delta.seconds // 3600} hours"
+        else:
+            delta_str = f"{delta.days} days"
+
+        await ctx.send(
+            "The Advent of Code event is not currently running. "
+            f"The next event will start in {delta_str}."
+        )
 
     @adventofcode_group.command(name="about", aliases=("ab", "info"), brief="Learn about Advent of Code")
     @whitelist_override(channels=AOC_WHITELIST)

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -101,14 +101,13 @@ class AdventOfCode(commands.Cog):
     async def aoc_countdown(self, ctx: commands.Context) -> None:
         """Return time left until next day."""
         if _helpers.is_in_advent():
-            tomorrow, time_left = _helpers.time_left_to_est_midnight()
-            hours, minutes = time_left.seconds // 3600, time_left.seconds // 60 % 60
+            tomorrow, _ = _helpers.time_left_to_est_midnight()
+            next_day_timestamp = int(tomorrow.timestamp())
 
-            await ctx.send(f"There are {hours} hours and {minutes} minutes left until day {tomorrow.day}.")
+            await ctx.send(f"Day {tomorrow.day} starts <t:{next_day_timestamp}:R>.")
             return
 
         datetime_now = arrow.now(_helpers.EST)
-
         # Calculate the delta to this & next year's December 1st to see which one is closest and not in the past
         this_year = arrow.get(datetime(datetime_now.year, 12, 1), _helpers.EST)
         next_year = arrow.get(datetime(datetime_now.year + 1, 12, 1), _helpers.EST)


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Swapped out our custom logic to create a human readable delta with a Discord time stamp.

This allows users to hover over the time stamp to get an exact date, along with automatically rounding to the most significant unit.

I have also added a refactor commit to swap the conditional block around, so the "smaller" code path is the one in the if statement, which makes the function easier to read.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/9753350/143855281-f0ad2587-b643-49d1-8665-11b105bc2c09.png)
![image](https://user-images.githubusercontent.com/9753350/143893068-5f44b414-8283-45b2-9cac-ab679cc4db9e.png)

After:
![image](https://user-images.githubusercontent.com/9753350/143855294-77333972-97b7-40c4-8513-00ecd943e0ff.png)
Discord time stamps round, rather than truncate like we were doing previously, which is why this says 2 days, rather than 1.
![image](https://user-images.githubusercontent.com/9753350/143892959-dd25d85d-c9d2-4c6b-a13b-728dc196db62.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
