### PR TITLE
Redirect aoc commands

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -11,12 +11,13 @@ from discord.ext import commands, tasks
 
 from bot.bot import Bot
 from bot.constants import (
-    AdventOfCode as AocConfig, Channels, Client, Colours, Emojis, Month, PYTHON_PREFIX, Roles, WHITELISTED_CHANNELS
+    AdventOfCode as AocConfig, Channels, Client, Colours, Emojis, Month, PYTHON_PREFIX, Roles, STAFF_ROLES,
+    WHITELISTED_CHANNELS
 )
 from bot.exts.events.advent_of_code import _helpers
 from bot.exts.events.advent_of_code.views.dayandstarview import AoCDropdownView
 from bot.utils import members
-from bot.utils.decorators import InChannelCheckFailure, in_month, whitelist_override, with_role
+from bot.utils.decorators import InChannelCheckFailure, in_month, redirect_output, whitelist_override, with_role
 from bot.utils.exceptions import MovedCommandError
 from bot.utils.extensions import invoke_help_command
 
@@ -119,6 +120,7 @@ class AdventOfCode(commands.Cog):
 
     @commands.group(name="adventofcode", aliases=("aoc",))
     @whitelist_override(channels=AOC_WHITELIST)
+    @redirect_output(destination_channel=Channels.advent_of_code_commands, bypass_roles=STAFF_ROLES)
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         if not ctx.invoked_subcommand:
@@ -145,6 +147,7 @@ class AdventOfCode(commands.Cog):
         help=f"NOTE: This command has been moved to {PYTHON_PREFIX}subscribe",
     )
     @whitelist_override(channels=AOC_WHITELIST)
+    @redirect_output(destination_channel=Channels.advent_of_code_commands, bypass_roles=STAFF_ROLES)
     async def aoc_subscribe(self, ctx: commands.Context) -> None:
         """
         Deprecated role command.
@@ -155,6 +158,7 @@ class AdventOfCode(commands.Cog):
 
     @adventofcode_group.command(name="countdown", aliases=("count", "c"), brief="Return time left until next day")
     @whitelist_override(channels=AOC_WHITELIST)
+    @redirect_output(destination_channel=Channels.advent_of_code_commands, bypass_roles=STAFF_ROLES)
     async def aoc_countdown(self, ctx: commands.Context) -> None:
         """Return time left until next day."""
         if _helpers.is_in_advent():
@@ -180,6 +184,7 @@ class AdventOfCode(commands.Cog):
 
     @adventofcode_group.command(name="about", aliases=("ab", "info"), brief="Learn about Advent of Code")
     @whitelist_override(channels=AOC_WHITELIST)
+    @redirect_output(destination_channel=Channels.advent_of_code_commands, bypass_roles=STAFF_ROLES)
     async def about_aoc(self, ctx: commands.Context) -> None:
         """Respond with an explanation of all things Advent of Code."""
         await ctx.send(embed=self.cached_about_aoc)
@@ -187,6 +192,7 @@ class AdventOfCode(commands.Cog):
     @commands.guild_only()
     @adventofcode_group.command(name="join", aliases=("j",), brief="Learn how to join the leaderboard (via DM)")
     @whitelist_override(channels=AOC_WHITELIST)
+    @redirect_output(destination_channel=Channels.advent_of_code_commands, bypass_roles=STAFF_ROLES)
     async def join_leaderboard(self, ctx: commands.Context) -> None:
         """DM the user the information for joining the Python Discord leaderboard."""
         current_date = datetime.now()

--- a/bot/utils/function.py
+++ b/bot/utils/function.py
@@ -1,0 +1,147 @@
+"""Utilities for interaction with functions."""
+
+import functools
+import inspect
+import logging
+import types
+import typing as t
+
+log = logging.getLogger(__name__)
+
+Argument = t.Union[int, str]
+BoundArgs = t.OrderedDict[str, t.Any]
+Decorator = t.Callable[[t.Callable], t.Callable]
+ArgValGetter = t.Callable[[BoundArgs], t.Any]
+
+
+class GlobalNameConflictError(Exception):
+    """Raised when there's a conflict between the globals used to resolve annotations of wrapped and its wrapper."""
+
+
+def get_arg_value(name_or_pos: Argument, arguments: BoundArgs) -> t.Any:
+    """
+    Return a value from `arguments` based on a name or position.
+
+    `arguments` is an ordered mapping of parameter names to argument values.
+
+    Raise TypeError if `name_or_pos` isn't a str or int.
+    Raise ValueError if `name_or_pos` does not match any argument.
+    """
+    if isinstance(name_or_pos, int):
+        # Convert arguments to a tuple to make them indexable.
+        arg_values = tuple(arguments.items())
+        arg_pos = name_or_pos
+
+        try:
+            name, value = arg_values[arg_pos]
+            return value
+        except IndexError:
+            raise ValueError(f"Argument position {arg_pos} is out of bounds.")
+    elif isinstance(name_or_pos, str):
+        arg_name = name_or_pos
+        try:
+            return arguments[arg_name]
+        except KeyError:
+            raise ValueError(f"Argument {arg_name!r} doesn't exist.")
+    else:
+        raise TypeError("'arg' must either be an int (positional index) or a str (keyword).")
+
+
+def get_arg_value_wrapper(
+    decorator_func: t.Callable[[ArgValGetter], Decorator],
+    name_or_pos: Argument,
+    func: t.Callable[[t.Any], t.Any] = None,
+) -> Decorator:
+    """
+    Call `decorator_func` with the value of the arg at the given name/position.
+
+    `decorator_func` must accept a callable as a parameter to which it will pass a mapping of
+    parameter names to argument values of the function it's decorating.
+
+    `func` is an optional callable which will return a new value given the argument's value.
+
+    Return the decorator returned by `decorator_func`.
+    """
+    def wrapper(args: BoundArgs) -> t.Any:
+        value = get_arg_value(name_or_pos, args)
+        if func:
+            value = func(value)
+        return value
+
+    return decorator_func(wrapper)
+
+
+def get_bound_args(func: t.Callable, args: t.Tuple, kwargs: t.Dict[str, t.Any]) -> BoundArgs:
+    """
+    Bind `args` and `kwargs` to `func` and return a mapping of parameter names to argument values.
+
+    Default parameter values are also set.
+    """
+    sig = inspect.signature(func)
+    bound_args = sig.bind(*args, **kwargs)
+    bound_args.apply_defaults()
+
+    return bound_args.arguments
+
+
+def update_wrapper_globals(
+        wrapper: types.FunctionType,
+        wrapped: types.FunctionType,
+        *,
+        ignored_conflict_names: t.Set[str] = frozenset(),
+) -> types.FunctionType:
+    """
+    Update globals of `wrapper` with the globals from `wrapped`.
+
+    For forwardrefs in command annotations discordpy uses the __global__ attribute of the function
+    to resolve their values, with decorators that replace the function this breaks because they have
+    their own globals.
+
+    This function creates a new function functionally identical to `wrapper`, which has the globals replaced with
+    a merge of `wrapped`s globals and the `wrapper`s globals.
+
+    An exception will be raised in case `wrapper` and `wrapped` share a global name that is used by
+    `wrapped`'s typehints and is not in `ignored_conflict_names`,
+    as this can cause incorrect objects being used by discordpy's converters.
+    """
+    annotation_global_names = (
+        ann.split(".", maxsplit=1)[0] for ann in wrapped.__annotations__.values() if isinstance(ann, str)
+    )
+    # Conflicting globals from both functions' modules that are also used in the wrapper and in wrapped's annotations.
+    shared_globals = set(wrapper.__code__.co_names) & set(annotation_global_names)
+    shared_globals &= set(wrapped.__globals__) & set(wrapper.__globals__) - ignored_conflict_names
+    if shared_globals:
+        raise GlobalNameConflictError(
+            f"wrapper and the wrapped function share the following "
+            f"global names used by annotations: {', '.join(shared_globals)}. Resolve the conflicts or add "
+            f"the name to the `ignored_conflict_names` set to suppress this error if this is intentional."
+        )
+
+    new_globals = wrapper.__globals__.copy()
+    new_globals.update((k, v) for k, v in wrapped.__globals__.items() if k not in wrapper.__code__.co_names)
+    return types.FunctionType(
+        code=wrapper.__code__,
+        globals=new_globals,
+        name=wrapper.__name__,
+        argdefs=wrapper.__defaults__,
+        closure=wrapper.__closure__,
+    )
+
+
+def command_wraps(
+        wrapped: types.FunctionType,
+        assigned: t.Sequence[str] = functools.WRAPPER_ASSIGNMENTS,
+        updated: t.Sequence[str] = functools.WRAPPER_UPDATES,
+        *,
+        ignored_conflict_names: t.Set[str] = frozenset(),
+) -> t.Callable[[types.FunctionType], types.FunctionType]:
+    """Update the decorated function to look like `wrapped` and update globals for discordpy forwardref evaluation."""
+    def decorator(wrapper: types.FunctionType) -> types.FunctionType:
+        return functools.update_wrapper(
+            update_wrapper_globals(wrapper, wrapped, ignored_conflict_names=ignored_conflict_names),
+            wrapped,
+            assigned,
+            updated,
+        )
+
+    return decorator


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This ports the redirect_output decorator from Python bot (first two commits) and then uses it to redirect all AoC commands that can be run in the main channel to the AoC commands channel

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
