### PR TITLE
Make self_placement_name keyword-only in .aoc lb

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -220,6 +220,7 @@ class AdventOfCode(commands.Cog):
     async def aoc_leaderboard(
             self,
             ctx: commands.Context,
+            *,
             self_placement_name: Optional[str] = None,
     ) -> None:
         """

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -217,25 +217,20 @@ class AdventOfCode(commands.Cog):
         brief="Get a snapshot of the PyDis private AoC leaderboard",
     )
     @whitelist_override(channels=AOC_WHITELIST_RESTRICTED)
-    async def aoc_leaderboard(
-            self,
-            ctx: commands.Context,
-            *,
-            self_placement_name: Optional[str] = None,
-    ) -> None:
+    async def aoc_leaderboard(self, ctx: commands.Context, *, aoc_name: Optional[str] = None) -> None:
         """
         Get the current top scorers of the Python Discord Leaderboard.
 
-        Additionally you can specify a `self_placement_name`
-        that will append the specified profile's personal stats to the top of the leaderboard
+        Additionally you can specify an `aoc_name` that will append the
+        specified profile's personal stats to the top of the leaderboard
         """
         # Strip quotes from the self placement name if needed (e.g. "My Name" -> My Name)
-        if self_placement_name and self_placement_name[0] == self_placement_name[-1] == '"':
-            self_placement_name = self_placement_name[1:-1]
+        if aoc_name and aoc_name.startswith('"') and aoc_name.endswith('"'):
+            aoc_name = aoc_name[1:-1]
 
         async with ctx.typing():
             try:
-                leaderboard = await _helpers.fetch_leaderboard(self_placement_name=self_placement_name)
+                leaderboard = await _helpers.fetch_leaderboard(self_placement_name=aoc_name)
             except _helpers.FetchingLeaderboardFailedError:
                 await ctx.send(":x: Unable to fetch leaderboard!")
                 return
@@ -243,10 +238,10 @@ class AdventOfCode(commands.Cog):
         number_of_participants = leaderboard["number_of_participants"]
 
         top_count = min(AocConfig.leaderboard_displayed_members, number_of_participants)
-        self_placement_header = "(and your personal stats compared to the top 10)" if self_placement_name else ""
+        self_placement_header = "(and your personal stats compared to the top 10)" if aoc_name else ""
         header = f"Here's our current top {top_count}{self_placement_header}! {Emojis.christmas_tree * 3}"
         table = "```\n" \
-                f"{leaderboard['placement_leaderboard'] if self_placement_name else leaderboard['top_leaderboard']}" \
+                f"{leaderboard['placement_leaderboard'] if aoc_name else leaderboard['top_leaderboard']}" \
                 "\n```"
         info_embed = _helpers.get_summary_embed(leaderboard)
 

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -224,7 +224,9 @@ class AdventOfCode(commands.Cog):
         Additionally you can specify an `aoc_name` that will append the
         specified profile's personal stats to the top of the leaderboard
         """
-        # Strip quotes from the self placement name if needed (e.g. "My Name" -> My Name)
+        # Strip quotes from the AoC username if needed (e.g. "My Name" -> My Name)
+        # Note: only strips one layer of quotes to allow names with quotes at the start and end
+        #      e.g. ""My Name"" -> "My Name"
         if aoc_name and aoc_name.startswith('"') and aoc_name.endswith('"'):
             aoc_name = aoc_name[1:-1]
 

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -229,6 +229,10 @@ class AdventOfCode(commands.Cog):
         Additionally you can specify a `self_placement_name`
         that will append the specified profile's personal stats to the top of the leaderboard
         """
+        # Strip quotes from the self placement name if needed (e.g. "My Name" -> My Name)
+        if self_placement_name and self_placement_name[0] == self_placement_name[-1] == '"':
+            self_placement_name = self_placement_name[1:-1]
+
         async with ctx.typing():
             try:
                 leaderboard = await _helpers.fetch_leaderboard(self_placement_name=self_placement_name)

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -225,6 +225,7 @@ class AdventOfCode(commands.Cog):
         specified profile's personal stats to the top of the leaderboard
         """
         # Strip quotes from the AoC username if needed (e.g. "My Name" -> My Name)
+        # This is to keep compatibility with those already used to wrapping the AoC name in quotes
         # Note: only strips one layer of quotes to allow names with quotes at the start and end
         #      e.g. ""My Name"" -> "My Name"
         if aoc_name and aoc_name.startswith('"') and aoc_name.endswith('"'):


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

Approved by @janine9vn: https://discord.com/channels/267624335836053506/635950537262759947/915806212367482891

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #962

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
I made `.adventofcode leaderboard`'s `self_placement_name` argument keyword-only to accept multi-word usernames without needing quotation marks.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
