### PR TITLE
Add `.aoc link` command

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -30,6 +30,7 @@ AOC_WHITELIST = AOC_WHITELIST_RESTRICTED + (Channels.advent_of_code,)
 class AdventOfCode(commands.Cog):
     """Advent of Code festivities! Ho Ho Ho!"""
 
+    # Redis Cache for linking Discord IDs to Advent of Code usernames
     account_links = RedisCache()
 
     def __init__(self, bot: Bot):
@@ -186,23 +187,9 @@ class AdventOfCode(commands.Cog):
         """
         Link your Discord Account to your Advent of Code name.
 
-        Stored in a Redis Cache, Discord ID: Advent of Code Name
+        Stored in a Redis Cache with the format of `Discord ID: Advent of Code Name`
         """
         cache_items = await self.account_links.items()
-
-        # A short circuit in case the cache is empty
-        if len(cache_items) == 0 and aoc_name:
-            log.info(f"{ctx.author} ({ctx.author.id}) is now linked to {aoc_name}.")
-            await self.account_links.set(ctx.author.id, aoc_name)
-            await ctx.reply(f"You have linked your Discord ID to {aoc_name}.")
-            return
-        elif len(cache_items) == 0:
-            await ctx.reply(
-                "You have not linked an Advent of Code account."
-                "Please re-run the command with one specified."
-            )
-            return
-
         cache_aoc_name = [value for _, value in cache_items]
 
         if aoc_name:

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -228,6 +228,27 @@ class AdventOfCode(commands.Cog):
                     " Please re-run the command with one specified."
                 )
 
+    @in_month(Month.NOVEMBER, Month.DECEMBER)
+    @adventofcode_group.command(
+        name="unlink",
+        aliases=("disconnect",),
+        brief="Tie your Discord account with your Advent of Code name."
+    )
+    @whitelist_override(channels=AOC_WHITELIST)
+    async def aoc_unlink_account(self, ctx: commands.Context) -> None:
+        """
+        Unlink your Discord ID with your Advent of Code leaderboard name.
+
+        Deletes the entry that was Stored in the Redis cache.
+        """
+        if aoc_cache_name := await self.account_links.get(ctx.author.id):
+            log.info(f"Unlinking {ctx.author} ({ctx.author.id}) from Advent of Code account {aoc_cache_name}")
+            await self.account_links.delete(ctx.author.id)
+            await ctx.reply(f"We have removed the link between your Discord ID and {aoc_cache_name}.")
+        else:
+            log.info(f"Attempted to unlink {ctx.author} ({ctx.author.id}), but not link was found.")
+            await ctx.reply("You don't have an Advent of Code account linked.")
+
     @in_month(Month.DECEMBER)
     @adventofcode_group.command(
         name="dayandstar",

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -210,12 +210,12 @@ class AdventOfCode(commands.Cog):
 
             # Update an existing link
             if old_aoc_name := await self.account_links.get(ctx.author.id):
-                log.info(f"{ctx.author} ({ctx.author.id}) has changed their link from {old_aoc_name} to {aoc_name}.")
+                log.info(f"Changing link for{ctx.author} ({ctx.author.id}) from {old_aoc_name} to {aoc_name}.")
                 await self.account_links.set(ctx.author.id, aoc_name)
                 await ctx.reply(f"Your linked account has been changed to {aoc_name}.")
             else:
                 # Create a new link
-                log.info(f"{ctx.author} ({ctx.author.id}) is now linked to {aoc_name}.")
+                log.info(f"Linking {ctx.author} ({ctx.author.id}) to account {aoc_name}.")
                 await self.account_links.set(ctx.author.id, aoc_name)
                 await ctx.reply(f"You have linked your Discord ID to {aoc_name}.")
         else:
@@ -246,7 +246,7 @@ class AdventOfCode(commands.Cog):
             await self.account_links.delete(ctx.author.id)
             await ctx.reply(f"We have removed the link between your Discord ID and {aoc_cache_name}.")
         else:
-            log.info(f"Attempted to unlink {ctx.author} ({ctx.author.id}), but not link was found.")
+            log.info(f"Attempted to unlink {ctx.author} ({ctx.author.id}), but no link was found.")
             await ctx.reply("You don't have an Advent of Code account linked.")
 
     @in_month(Month.DECEMBER)

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -183,7 +183,7 @@ class AdventOfCode(commands.Cog):
         brief="Tie your Discord account with your Advent of Code name."
     )
     @whitelist_override(channels=AOC_WHITELIST)
-    async def aoc_link_account(self, ctx: commands.Context, aoc_name: str = None) -> None:
+    async def aoc_link_account(self, ctx: commands.Context, *, aoc_name: str = None) -> None:
         """
         Link your Discord Account to your Advent of Code name.
 

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -193,14 +193,14 @@ class AdventOfCode(commands.Cog):
         Stored in a Redis Cache with the format of `Discord ID: Advent of Code Name`
         """
         cache_items = await self.account_links.items()
-        cache_aoc_name = [value for _, value in cache_items]
+        cache_aoc_names = [value for _, value in cache_items]
 
         if aoc_name:
             # Let's check the current values in the cache to make sure it isn't already tied to a different account
             if aoc_name == await self.account_links.get(ctx.author.id):
                 await ctx.reply(f"{aoc_name} is already tied to your account.")
                 return
-            elif aoc_name in cache_aoc_name:
+            elif aoc_name in cache_aoc_names:
                 log.info(
                     f"{ctx.author} ({ctx.author.id}) tried to connect their account to {aoc_name},"
                     " but it's already connected to another user."
@@ -213,7 +213,7 @@ class AdventOfCode(commands.Cog):
 
             # Update an existing link
             if old_aoc_name := await self.account_links.get(ctx.author.id):
-                log.info(f"Changing link for{ctx.author} ({ctx.author.id}) from {old_aoc_name} to {aoc_name}.")
+                log.info(f"Changing link for {ctx.author} ({ctx.author.id}) from {old_aoc_name} to {aoc_name}.")
                 await self.account_links.set(ctx.author.id, aoc_name)
                 await ctx.reply(f"Your linked account has been changed to {aoc_name}.")
             else:

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -311,6 +311,10 @@ class AdventOfCode(commands.Cog):
         if aoc_name and aoc_name.startswith('"') and aoc_name.endswith('"'):
             aoc_name = aoc_name[1:-1]
 
+        # Check if an advent of code account is linked in the Redis Cache if aoc_name is not given
+        if (aoc_cache_name := await self.account_links.get(ctx.author.id)) and aoc_name is None:
+            aoc_name = aoc_cache_name
+
         async with ctx.typing():
             try:
                 leaderboard = await _helpers.fetch_leaderboard(self_placement_name=aoc_name)
@@ -321,7 +325,7 @@ class AdventOfCode(commands.Cog):
         number_of_participants = leaderboard["number_of_participants"]
 
         top_count = min(AocConfig.leaderboard_displayed_members, number_of_participants)
-        self_placement_header = "(and your personal stats compared to the top 10)" if aoc_name else ""
+        self_placement_header = " (and your personal stats compared to the top 10)" if aoc_name else ""
         header = f"Here's our current top {top_count}{self_placement_header}! {Emojis.christmas_tree * 3}"
         table = "```\n" \
                 f"{leaderboard['placement_leaderboard'] if aoc_name else leaderboard['top_leaderboard']}" \

--- a/bot/exts/events/advent_of_code/_helpers.py
+++ b/bot/exts/events/advent_of_code/_helpers.py
@@ -216,6 +216,9 @@ def _format_leaderboard(leaderboard: dict[str, dict], self_placement_name: str =
     if self_placement_name and not self_placement_exists:
         raise commands.BadArgument(
             "Sorry, your profile does not exist in this leaderboard."
+            "\n\n"
+            "To join our leaderboard, run the command `.aoc join`."
+            " If you've joined recently, please wait up to 30 minutes for our leaderboard to refresh."
         )
     return "\n".join(leaderboard_lines)
 


### PR DESCRIPTION
## Description
This adds functionality to the Advent of Code cog for users to "link" their Discord Account with their Advent of Code name on the leaderboard. The cog doesn't explicitly make use of it, but it is necessary to exist and be functional for something I want to do. 

This is implemented with a Redis Cache. A user can link their discord account with a name they specify and it's stored as a key-value pair with the Discord ID as the key.

There is no validation that the name they are entering is on our leaderboard. This is an intentional decision as I don't want to rely on the leaderboard cooldown for a user to successfully run this command. If a user fucks up their name, that's on them. It does check if the name they are trying to link is already in the cache and provides the appropriate response.

To test this command you can run the following two commands in different scenarios:
`.aoc link`
`.aoc link aocnamehere`

## Relevant Issues
Closes #958 
