### PR TITLE
nit: make last refreshed time above the rest of the embed

### DIFF
--- a/bot/exts/events/advent_of_code/_helpers.py
+++ b/bot/exts/events/advent_of_code/_helpers.py
@@ -332,7 +332,7 @@ async def fetch_leaderboard(invalidate_cache: bool = False, self_placement_name:
         number_of_participants = len(leaderboard)
         formatted_leaderboard = _format_leaderboard(leaderboard)
         full_leaderboard_url = await _upload_leaderboard(formatted_leaderboard)
-        leaderboard_fetched_at = datetime.datetime.utcnow().isoformat()
+        leaderboard_fetched_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
         cached_leaderboard = {
             "placement_leaderboard": json.dumps(raw_leaderboard_data),

--- a/bot/exts/events/advent_of_code/_helpers.py
+++ b/bot/exts/events/advent_of_code/_helpers.py
@@ -368,11 +368,13 @@ def get_summary_embed(leaderboard: dict) -> discord.Embed:
     """Get an embed with the current summary stats of the leaderboard."""
     leaderboard_url = leaderboard["full_leaderboard_url"]
     refresh_minutes = AdventOfCode.leaderboard_cache_expiry_seconds // 60
+    refreshed_unix = int(datetime.datetime.fromisoformat(leaderboard["leaderboard_fetched_at"]).timestamp())
 
-    aoc_embed = discord.Embed(
-        colour=Colours.soft_green,
-        timestamp=datetime.datetime.fromisoformat(leaderboard["leaderboard_fetched_at"]),
-        description=f"*The leaderboard is refreshed every {refresh_minutes} minutes.*"
+    aoc_embed = discord.Embed(colour=Colours.soft_green)
+
+    aoc_embed.description = (
+        f"The leaderboard is refreshed every {refresh_minutes} minutes.\n"
+        f"Last Updated: <t:{refreshed_unix}:t>"
     )
     aoc_embed.add_field(
         name="Number of Participants",
@@ -386,7 +388,6 @@ def get_summary_embed(leaderboard: dict) -> discord.Embed:
             inline=True,
         )
     aoc_embed.set_author(name="Advent of Code", url=leaderboard_url)
-    aoc_embed.set_footer(text="Last Updated")
     aoc_embed.set_thumbnail(url=AOC_EMBED_THUMBNAIL)
 
     return aoc_embed


### PR DESCRIPTION
discussed on discord, using this implementation from zig: 
![image](https://user-images.githubusercontent.com/71233171/144665037-4223e578-eba5-4129-a8c6-e8425a3ccbca.png)

closes #967 
closes #966 (indirectly)

new embed: 
![image](https://user-images.githubusercontent.com/71233171/144665184-51725d85-3917-4e1a-936b-b0978307f57a.png)


Edit: did not link the discussion: https://canary.discord.com/channels/267624335836053506/635950537262759947/916405655630389310