### PR TITLE
Fix message converter

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -43,6 +43,11 @@ if os.name == "nt":
 
 monkey_patches.patch_typing()
 
+# This patches any convertors that use PartialMessage, but not the PartialMessageConverter itself
+# as library objects are made by this mapping.
+# https://github.com/Rapptz/discord.py/blob/1a4e73d59932cdbe7bf2c281f25e32529fc7ae1f/discord/ext/commands/converter.py#L984-L1004
+commands.converter.PartialMessageConverter = monkey_patches.FixedPartialMessageConverter
+
 # Monkey-patch discord.py decorators to use the both the Command and Group subclasses which supports root aliases.
 # Must be patched before any cogs are added.
 commands.command = partial(commands.command, cls=monkey_patches.Command)

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -102,7 +102,7 @@ class Bookmark(commands.Cog):
                     "You must either provide a valid message to bookmark, or reply to one."
                     "\n\nThe lookup strategy for a message is as follows (in order):"
                     "\n1. Lookup by '{channel ID}-{message ID}' (retrieved by shift-clicking on 'Copy ID')"
-                    "\n2. Lookup by message ID (the message **must** have been sent after the bot last started)"
+                    "\n2. Lookup by message ID (the message **must** be in the context channel)"
                     "\n3. Lookup by message URL"
                 )
             target_message = ctx.message.reference.resolved

--- a/bot/monkey_patches.py
+++ b/bot/monkey_patches.py
@@ -1,10 +1,12 @@
 import logging
+import re
 from datetime import datetime, timedelta
 
 from discord import Forbidden, http
 from discord.ext import commands
 
 log = logging.getLogger(__name__)
+MESSAGE_ID_RE = re.compile(r'(?P<message_id>[0-9]{15,20})$')
 
 
 class Command(commands.Command):
@@ -65,3 +67,25 @@ def patch_typing() -> None:
             pass
 
     http.HTTPClient.send_typing = honeybadger_type
+
+
+class FixedPartialMessageConverter(commands.PartialMessageConverter):
+    """
+    Make the Message converter infer channelID from the given context if only a messageID is given.
+
+    Discord.py's Message converter is supposed to infer channelID based
+    on ctx.channel if only a messageID is given. A refactor commit, linked below,
+    a few weeks before d.py's archival broke this defined behaviour of the converter.
+    Currently, if only a messageID is given to the converter, it will only find that message
+    if it's in the bot's cache.
+
+    https://github.com/Rapptz/discord.py/commit/1a4e73d59932cdbe7bf2c281f25e32529fc7ae1f
+    """
+
+    @staticmethod
+    def _get_id_matches(ctx: commands.Context, argument: str) -> tuple[int, int, int]:
+        """Inserts ctx.channel.id before calling super method if argument is just a messageID."""
+        match = MESSAGE_ID_RE.match(argument)
+        if match:
+            argument = f"{ctx.channel.id}-{match.group('message_id')}"
+        return commands.PartialMessageConverter._get_id_matches(ctx, argument)


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Ported from https://github.com/python-discord/bot/pull/1990/

Discord.py's message converter is supposed to infer channelID based on ctx.channel if only a messageID is given. A refactor (linked below) a few weeks before d.py's archival broke this, so that if only a messageID is given to the converter, it will only find that message if it's in the bot's cache.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
