### PR TITLE
Give AoC completer role to members with 50 stars

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -291,6 +291,7 @@ class Roles(NamedTuple):
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     core_developers = 587606783669829632
     everyone = int(environ.get("BOT_GUILD", 267624335836053506))
+    aoc_completionist = int(environ.get("AOC_COMPLETIONIST_ROLE_ID", 916691790181056532))
 
 
 class Tokens(NamedTuple):

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -100,16 +100,11 @@ class AdventOfCode(commands.Cog):
                 continue
 
             member = await members.get_or_fetch_member(guild, member_id)
-            if member is None:
+            if member is None or completionist_role in member.roles:
                 continue
 
-            if completionist_role in member.roles:
-                continue
-
-            if await self.completionist_block_list.contains(member_id):
-                continue
-
-            await members.handle_role_change(member, member.add_roles, completionist_role)
+            if not await self.completionist_block_list.contains(member_id):
+                await members.handle_role_change(member, member.add_roles, completionist_role)
 
     @commands.group(name="adventofcode", aliases=("aoc",))
     @whitelist_override(channels=AOC_WHITELIST)

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -125,6 +125,7 @@ class AdventOfCode(commands.Cog):
             await member.remove_roles(completionist_role)
 
         await self.completionist_block_list.set(member.id, "sentinel")
+        await ctx.send(f":+1: Blocked {member.mention} from getting the AoC completionist role.")
 
     @commands.guild_only()
     @adventofcode_group.command(

--- a/bot/utils/members.py
+++ b/bot/utils/members.py
@@ -1,0 +1,47 @@
+import logging
+import typing as t
+
+import discord
+
+log = logging.getLogger(__name__)
+
+
+async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> t.Optional[discord.Member]:
+    """
+    Attempt to get a member from cache; on failure fetch from the API.
+
+    Return `None` to indicate the member could not be found.
+    """
+    if member := guild.get_member(member_id):
+        log.trace("%s retrieved from cache.", member)
+    else:
+        try:
+            member = await guild.fetch_member(member_id)
+        except discord.errors.NotFound:
+            log.trace("Failed to fetch %d from API.", member_id)
+            return None
+        log.trace("%s fetched from API.", member)
+    return member
+
+
+async def handle_role_change(
+    member: discord.Member,
+    coro: t.Callable[..., t.Coroutine],
+    role: discord.Role
+) -> None:
+    """
+    Change `member`'s cooldown role via awaiting `coro` and handle errors.
+
+    `coro` is intended to be `discord.Member.add_roles` or `discord.Member.remove_roles`.
+    """
+    try:
+        await coro(role)
+    except discord.NotFound:
+        log.debug(f"Failed to change role for {member} ({member.id}): member not found")
+    except discord.Forbidden:
+        log.debug(
+            f"Forbidden to change role for {member} ({member.id}); "
+            f"possibly due to role hierarchy"
+        )
+    except discord.HTTPException as e:
+        log.error(f"Failed to change role for {member} ({member.id}): {e.status} {e.code}")


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This PR adds ~~an hourly task~~ a task that runs every 10 minutes to give a specific role to users who have completed all 50 stars and linked their Discord accounts. The role itself gives users a nice vanity role icon to show off their accomplishment.

This uses the cached leaderboard, so doesn't add any extra calls to the AoC API.

I have also added a command to block members from getting this role. This could be used where we have believe that the user in question didn't complete the stars themselves (such as copying answers from the internet).

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
