### PR TITLE
Add logging to aoc completer task

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -74,7 +74,7 @@ class AdventOfCode(commands.Cog):
         completionist_role = guild.get_role(Roles.aoc_completionist)
         if completionist_role is None:
             log.warning("Could not find the AoC completionist role; cancelling completionist task.")
-            self.completer_task.cancel()
+            self.completionist_task.cancel()
             return
 
         aoc_name_to_member_id = {
@@ -97,13 +97,20 @@ class AdventOfCode(commands.Cog):
 
             member_id = aoc_name_to_member_id.get(member_aoc_info["name"], None)
             if not member_id:
+                log.debug(f"Could not find member_id for {member_aoc_info['name']}, not giving role.")
                 continue
 
             member = await members.get_or_fetch_member(guild, member_id)
-            if member is None or completionist_role in member.roles:
+            if member is None:
+                log.debug(f"Could not find {member_id}, not giving role.")
+                continue
+
+            if completionist_role in member.roles:
+                log.debug(f"{member.name} ({member.mention}) already has the completionist role.")
                 continue
 
             if not await self.completionist_block_list.contains(member_id):
+                log.debug(f"Giving completionist role to {member.name} ({member.mention}).")
                 await members.handle_role_change(member, member.add_roles, completionist_role)
 
     @commands.group(name="adventofcode", aliases=("aoc",))

--- a/bot/utils/members.py
+++ b/bot/utils/members.py
@@ -39,7 +39,7 @@ async def handle_role_change(
     except discord.NotFound:
         log.debug(f"Failed to change role for {member} ({member.id}): member not found")
     except discord.Forbidden:
-        log.debug(
+        log.error(
             f"Forbidden to change role for {member} ({member.id}); "
             f"possibly due to role hierarchy"
         )


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This adds some logging to AoC role task to help with debugging issues, along with raising error when bot can't modify the given role in member helper util, rather than silencing it.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?

<–– Chris doesn’t have the authority to refuse––>