### PR TITLE
AoC month changes

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -254,7 +254,7 @@ class AdventOfCode(commands.Cog):
         else:
             await ctx.message.add_reaction(Emojis.envelope)
 
-    @in_month(Month.NOVEMBER, Month.DECEMBER)
+    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY)
     @adventofcode_group.command(
         name="link",
         aliases=("connect",),
@@ -306,7 +306,7 @@ class AdventOfCode(commands.Cog):
                     " Please re-run the command with one specified."
                 )
 
-    @in_month(Month.NOVEMBER, Month.DECEMBER)
+    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY)
     @adventofcode_group.command(
         name="unlink",
         aliases=("disconnect",),
@@ -327,7 +327,7 @@ class AdventOfCode(commands.Cog):
             log.info(f"Attempted to unlink {ctx.author} ({ctx.author.id}), but no link was found.")
             await ctx.reply("You don't have an Advent of Code account linked.")
 
-    @in_month(Month.DECEMBER)
+    @in_month(Month.DECEMBER, Month.JANUARY)
     @adventofcode_group.command(
         name="dayandstar",
         aliases=("daynstar", "daystar"),
@@ -365,7 +365,7 @@ class AdventOfCode(commands.Cog):
         await view.wait()
         await message.edit(view=None)
 
-    @in_month(Month.DECEMBER)
+    @in_month(Month.DECEMBER, Month.JANUARY)
     @adventofcode_group.command(
         name="leaderboard",
         aliases=("board", "lb"),
@@ -410,7 +410,7 @@ class AdventOfCode(commands.Cog):
         await ctx.send(content=f"{header}\n\n{table}", embed=info_embed)
         return
 
-    @in_month(Month.DECEMBER)
+    @in_month(Month.DECEMBER, Month.JANUARY)
     @adventofcode_group.command(
         name="global",
         aliases=("globalboard", "gb"),

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -213,9 +213,13 @@ class AdventOfCode(commands.Cog):
     @whitelist_override(channels=AOC_WHITELIST)
     async def join_leaderboard(self, ctx: commands.Context) -> None:
         """DM the user the information for joining the Python Discord leaderboard."""
-        current_year = datetime.now().year
-        if current_year != AocConfig.year:
-            await ctx.send(f"The Python Discord leaderboard for {current_year} is not yet available!")
+        current_date = datetime.now()
+        if (
+            current_date.month not in (Month.NOVEMBER, Month.DECEMBER) and current_date.year != AocConfig.year or
+            current_date.month != Month.JANUARY and current_date.year != AocConfig.year + 1
+        ):
+            # Only allow joining the leaderboard in the run up to AOC and the January following.
+            await ctx.send(f"The Python Discord leaderboard for {current_date.year} is not yet available!")
             return
 
         author = ctx.author

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,11 @@ ignore=
     # Docstring Quotes
     D301,D302,
     # Docstring Content
-    D400,D401,D402,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D416,D417
+    D400,D401,D402,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D416,D417,
     # Type Annotations
-    ANN002,ANN003,ANN101,ANN102,ANN204,ANN206
+    ANN002,ANN003,ANN101,ANN102,ANN204,ANN206,
+    # Binary operators over multiple lines
+    W504,
 exclude=
     __pycache__,.cache,
     venv,.venv,


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This allows AoC commands to be ran in January, along with limiting AoC join to only be ran in Nov, Dec and Jan.

This also removes the aoc subscribe command, since Python has a replacement for it now.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [ ] Join the [**Python Discord Community**](https://discord.gg/python)?
- [ ] Read all the comments in this template?
- [ ] Ensure there is an issue open, or link relevant discord discussions?
- [ ] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
