### PR TITLE
Update GitHub issue closed emoji

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -197,7 +197,7 @@ class Emojis:
 
     # These icons are from Github's repo https://github.com/primer/octicons/
     issue_open = "<:IssueOpen:852596024777506817>"
-    issue_closed = "<:IssueClosed:852596024739758081>"
+    issue_closed = "<:IssueClosed:927326162861039626>"
     issue_draft = "<:IssueDraft:852596025147523102>"  # Not currently used by Github, but here for future.
     pull_request_open = "<:PROpen:852596471505223781>"
     pull_request_closed = "<:PRClosed:852596024732286976>"


### PR DESCRIPTION
GitHub updated their issue closed emoji from red to purple, this updates the emoji to relfect that new colour.

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
