### PR TITLE
fix OverflowError in epoch command

### DIFF
--- a/bot/exts/utilities/epoch.py
+++ b/bot/exts/utilities/epoch.py
@@ -35,7 +35,7 @@ class DateString(commands.Converter):
         """
         try:
             return arrow.utcnow().dehumanize(argument)
-        except ValueError:
+        except (ValueError, OverflowError):
             try:
                 dt, ignored_tokens = parser.parse(argument, fuzzy_with_tokens=True)
             except parser.ParserError:


### PR DESCRIPTION
## Relevant Issues
Closes #1004 

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
Ignore `OverflowError` when parsing relative times. `BadArgument` is raised in the absolute time part of the converter if it cannot be converted there

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
