### PR TITLE
Fix aoc join in date logic

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -187,9 +187,10 @@ class AdventOfCode(commands.Cog):
     async def join_leaderboard(self, ctx: commands.Context) -> None:
         """DM the user the information for joining the Python Discord leaderboard."""
         current_date = datetime.now()
-        if (
-            current_date.month not in (Month.NOVEMBER, Month.DECEMBER) and current_date.year != AocConfig.year or
-            current_date.month != Month.JANUARY and current_date.year != AocConfig.year + 1
+        allowed_months = (Month.NOVEMBER.value, Month.DECEMBER.value)
+        if not (
+            current_date.month in allowed_months and current_date.year == AocConfig.year or
+            current_date.month == Month.JANUARY.value and current_date.year == AocConfig.year + 1
         ):
             # Only allow joining the leaderboard in the run up to AOC and the January following.
             await ctx.send(f"The Python Discord leaderboard for {current_date.year} is not yet available!")


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Not using `.value` meant it was pulling the enum name, and therefore was failing the check.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
