### PR TITLE
Fix AoC name lookup for anon users

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -96,7 +96,9 @@ class AdventOfCode(commands.Cog):
                 # Only give the role to people who have completed all 50 stars
                 continue
 
-            member_id = aoc_name_to_member_id.get(member_aoc_info["name"], None)
+            aoc_name = member_aoc_info["name"] or f"Anonymous #{member_aoc_info['id']}"
+
+            member_id = aoc_name_to_member_id.get(aoc_name)
             if not member_id:
                 log.debug(f"Could not find member_id for {member_aoc_info['name']}, not giving role.")
                 continue


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
When a user doesn't set a name, the AoC API doesn't return a name key at all, so we need to make use of the ID field instead, to build the name based on a similar tempalte that AoC uses for it's leaderboard.
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
