### PR TITLE
Fix `.love` references to deprecated unsub command

### DIFF
--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -51,7 +51,7 @@ class LoveCalculator(Cog):
             raise BadArgument(
                 "This command can only be ran against members with the lovefest role! "
                 "This role be can assigned by running "
-                f"`{Client.prefix}lovefest sub` in <#{Channels.community_bot_commands}>."
+                f"`{PYTHON_PREFIX}subscribe` in <#{Channels.bot}>."
             )
 
         if whom is None:

--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -12,7 +12,7 @@ from discord.ext import commands
 from discord.ext.commands import BadArgument, Cog, clean_content
 
 from bot.bot import Bot
-from bot.constants import Channels, Client, Lovefest, Month, PYTHON_PREFIX
+from bot.constants import Channels, Lovefest, Month, PYTHON_PREFIX
 from bot.utils.decorators import in_month
 
 log = logging.getLogger(__name__)

--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -90,7 +90,7 @@ class LoveCalculator(Cog):
             name="A letter from Dr. Love:",
             value=data["text"]
         )
-        embed.set_footer(text=f"You can unsubscribe from lovefest by using {Client.prefix}lovefest unsub")
+        embed.set_footer(text="You can unsubscribe from lovefest by using !subscribe")
 
         await ctx.send(embed=embed)
 

--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -90,7 +90,7 @@ class LoveCalculator(Cog):
             name="A letter from Dr. Love:",
             value=data["text"]
         )
-        embed.set_footer(text="You can unsubscribe from lovefest by using !subscribe")
+        embed.set_footer(text="You can unsubscribe from lovefest by using !subscribe.")
 
         await ctx.send(embed=embed)
 

--- a/bot/exts/holidays/valentines/lovecalculator.py
+++ b/bot/exts/holidays/valentines/lovecalculator.py
@@ -12,7 +12,7 @@ from discord.ext import commands
 from discord.ext.commands import BadArgument, Cog, clean_content
 
 from bot.bot import Bot
-from bot.constants import Channels, Client, Lovefest, Month
+from bot.constants import Channels, Client, Lovefest, Month, PYTHON_PREFIX
 from bot.utils.decorators import in_month
 
 log = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class LoveCalculator(Cog):
             name="A letter from Dr. Love:",
             value=data["text"]
         )
-        embed.set_footer(text="You can unsubscribe from lovefest by using !subscribe.")
+        embed.set_footer(text=f"You can unsubscribe from lovefest by using {PYTHON_PREFIX}subscribe.")
 
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
## Relevant Issues
https://discord.com/channels/267624335836053506/635950537262759947/937865211254304778

## Description
This changes two references in the `.love` command to point to `!subscribe` instead of the deprecated `.lovefest unsub` command.

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
