### PR TITLE
Fixing typo in `Roles.admin`

### DIFF
--- a/bot/exts/events/trivianight/trivianight.py
+++ b/bot/exts/events/trivianight/trivianight.py
@@ -15,7 +15,7 @@ from ._questions import QuestionView
 from ._scoreboard import Scoreboard
 
 # The ID you see below are the Events Lead role ID and the Event Runner Role ID
-TRIVIA_NIGHT_ROLES = (Roles.admin, 778361735739998228, 940911658799333408)
+TRIVIA_NIGHT_ROLES = (Roles.admins, 778361735739998228, 940911658799333408)
 
 
 class TriviaNightCog(commands.Cog):


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #1025 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Changed `Roles.admin` to `Roles.admins` to prevent an error.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
