### PR TITLE
Disable AoC completionist task

### DIFF
--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -59,7 +59,8 @@ class AdventOfCode(commands.Cog):
         status_coro = _helpers.countdown_status(self.bot)
         self.status_task = self.bot.loop.create_task(status_coro)
         self.status_task.set_name("AoC Status Countdown")
-        self.status_task.add_done_callback(_helpers.background_task_callback)
+        # Don't start task while event isn't running
+        # self.status_task.add_done_callback(_helpers.background_task_callback)
 
         self.completionist_task.start()
 

--- a/bot/exts/events/advent_of_code/_cog.py
+++ b/bot/exts/events/advent_of_code/_cog.py
@@ -59,10 +59,10 @@ class AdventOfCode(commands.Cog):
         status_coro = _helpers.countdown_status(self.bot)
         self.status_task = self.bot.loop.create_task(status_coro)
         self.status_task.set_name("AoC Status Countdown")
-        # Don't start task while event isn't running
-        # self.status_task.add_done_callback(_helpers.background_task_callback)
+        self.status_task.add_done_callback(_helpers.background_task_callback)
 
-        self.completionist_task.start()
+        # Don't start task while event isn't running
+        # self.completionist_task.start()
 
     @tasks.loop(minutes=10.0)
     async def completionist_task(self) -> None:


### PR DESCRIPTION
This disabled the completionist task that checks the leaderboard for people who have 50 stars and gives out the role. Since the event is running, we are not keeping the session cookies up to date, so this is flooding #dev-log with errors.

This task should be altered in preparation for next event so that commenting out this line isn't required.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
