### PR TITLE
Calling `.realpython` with no args displays home page

### DIFF
--- a/bot/exts/utilities/realpython.py
+++ b/bot/exts/utilities/realpython.py
@@ -38,7 +38,7 @@ class RealPython(commands.Cog):
         By default the top 5 matches are sent, this can be overwritten to
         a number between 1 and 5 by specifying an amount before the search query.
         """
-        if user_search is None:
+        if (user_search is None):
             await ctx.send(HOME_URL)
             return
     

--- a/bot/exts/utilities/realpython.py
+++ b/bot/exts/utilities/realpython.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 API_ROOT = "https://realpython.com/search/api/v1/"
 ARTICLE_URL = "https://realpython.com{article_url}"
 SEARCH_URL = "https://realpython.com/search?q={user_search}"
-
+HOME_URL = "https://realpython.com/"
 
 ERROR_EMBED = Embed(
     title="Error while searching Real Python",
@@ -32,13 +32,16 @@ class RealPython(commands.Cog):
 
     @commands.command(aliases=["rp"])
     @commands.cooldown(1, 10, commands.cooldowns.BucketType.user)
-    async def realpython(self, ctx: commands.Context, amount: Optional[int] = 5, *, user_search: str) -> None:
+    async def realpython(self, ctx: commands.Context, amount: Optional[int] = 5, *, user_search: str=None) -> None:
         """
         Send some articles from RealPython that match the search terms.
-
         By default the top 5 matches are sent, this can be overwritten to
         a number between 1 and 5 by specifying an amount before the search query.
         """
+        if user_search is None:
+            await ctx.send(HOME_URL)
+            return
+    
         if not 1 <= amount <= 5:
             await ctx.send("`amount` must be between 1 and 5 (inclusive).")
             return


### PR DESCRIPTION
## Relevant Issues
Closes #1001

display realpython home page on blank `.realpython` command

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
