### PR TITLE
Add run bot step during lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Run pre-commit & flake8
+    name: Run linting & tests
     runs-on: ubuntu-latest
     env:
       # List of licenses that are compatible with the MIT License and
@@ -85,6 +85,14 @@ jobs:
         run: |
           pip-licenses --allow-only="$ALLOWED_LICENSE" \
             --package $(poetry export -f requirements.txt --without-hashes | sed "s/==.*//g" | tr "\n" " ")
+
+      # Attempt to run the bot. Setting `IN_CI` to true, so bot.run() is never called.
+      # This is to catch import and cog setup errors that may appear in PRs, to avoid crash loops if merged.
+      - name: Attempt bot setup
+        run: "python -m bot"
+        env:
+          USE_FAKEREDIS: true
+          IN_CI: true
 
       # This step caches our pre-commit environment. To make sure we
       # do create a new environment when our pre-commit setup changes,

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -12,4 +12,5 @@ bot.add_check(whitelist_check(channels=WHITELISTED_CHANNELS, roles=STAFF_ROLES))
 for ext in walk_extensions():
     bot.load_extension(ext)
 
-bot.run(Client.token)
+if not Client.in_ci:
+    bot.run(Client.token)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -143,6 +143,7 @@ class Client(NamedTuple):
     prefix = environ.get("PREFIX", ".")
     token = environ.get("BOT_TOKEN")
     debug = environ.get("BOT_DEBUG", "true").lower() == "true"
+    in_ci = environ.get("IN_CI", "false").lower() == "true"
     github_bot_repo = "https://github.com/python-discord/sir-lancebot"
     # Override seasonal locks: 1 (January) to 12 (December)
     month_override = int(environ["MONTH_OVERRIDE"]) if "MONTH_OVERRIDE" in environ else None


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This adds a step to our linting action to catch errors in imports/cog setup functions before they are merged by running the bot package, but not actually calling `bot.run()`.

Adding it to the lint flow means we already have the code checked out and a poetry env, so it adds ~1s to CI time.

See here fir a passing action https://github.com/ChrisLovering/sir-lancebot/runs/5264386120?check_suite_focus=true
This is a failing one https://github.com/ChrisLovering/sir-lancebot/runs/5264408507?check_suite_focus=true

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
