### PR TITLE
truncate output.

### DIFF
--- a/bot/exts/core/internal_eval/_internal_eval.py
+++ b/bot/exts/core/internal_eval/_internal_eval.py
@@ -34,6 +34,8 @@ RAW_CODE_REGEX = re.compile(
     re.DOTALL                               # "." also matches newlines
 )
 
+MAX_LENGTH = 99980
+
 
 class InternalEval(commands.Cog):
     """Top secret code evaluation for admins and owners."""
@@ -48,7 +50,7 @@ class InternalEval(commands.Cog):
     @staticmethod
     def shorten_output(
             output: str,
-            max_length: int = 99980,
+            max_length: int = 1900,
             placeholder: str = "\n[output truncated]"
     ) -> str:
         """
@@ -85,7 +87,7 @@ class InternalEval(commands.Cog):
 
     async def _upload_output(self, output: str) -> Optional[str]:
         """Upload `internal eval` output to our pastebin and return the url."""
-        data = self.shorten_output(output)
+        data = self.shorten_output(output, max_length=MAX_LENGTH)
         try:
             async with self.bot.http_session.post(
                 "https://paste.pythondiscord.com/documents", data=data, raise_for_status=True

--- a/bot/exts/core/internal_eval/_internal_eval.py
+++ b/bot/exts/core/internal_eval/_internal_eval.py
@@ -34,8 +34,6 @@ RAW_CODE_REGEX = re.compile(
     re.DOTALL                               # "." also matches newlines
 )
 
-MAX_LENGTH = 99980
-
 
 class InternalEval(commands.Cog):
     """Top secret code evaluation for admins and owners."""
@@ -50,7 +48,7 @@ class InternalEval(commands.Cog):
     @staticmethod
     def shorten_output(
             output: str,
-            max_length: int = 1900,
+            max_length: int = 99980,
             placeholder: str = "\n[output truncated]"
     ) -> str:
         """
@@ -87,7 +85,7 @@ class InternalEval(commands.Cog):
 
     async def _upload_output(self, output: str) -> Optional[str]:
         """Upload `internal eval` output to our pastebin and return the url."""
-        data = self.shorten_output(output, max_length=MAX_LENGTH)
+        data = self.shorten_output(output)
         try:
             async with self.bot.http_session.post(
                 "https://paste.pythondiscord.com/documents", data=data, raise_for_status=True

--- a/bot/exts/core/internal_eval/_internal_eval.py
+++ b/bot/exts/core/internal_eval/_internal_eval.py
@@ -34,6 +34,8 @@ RAW_CODE_REGEX = re.compile(
     re.DOTALL                               # "." also matches newlines
 )
 
+MAX_LENGTH = 99980
+
 
 class InternalEval(commands.Cog):
     """Top secret code evaluation for admins and owners."""
@@ -85,7 +87,7 @@ class InternalEval(commands.Cog):
 
     async def _upload_output(self, output: str) -> Optional[str]:
         """Upload `internal eval` output to our pastebin and return the url."""
-        data = self.shorten_output(output, max_length=99980)
+        data = self.shorten_output(output, max_length=MAX_LENGTH)
         try:
             async with self.bot.http_session.post(
                 "https://paste.pythondiscord.com/documents", data=data, raise_for_status=True

--- a/bot/exts/core/internal_eval/_internal_eval.py
+++ b/bot/exts/core/internal_eval/_internal_eval.py
@@ -85,9 +85,10 @@ class InternalEval(commands.Cog):
 
     async def _upload_output(self, output: str) -> Optional[str]:
         """Upload `internal eval` output to our pastebin and return the url."""
+        data = self.shorten_output(output, max_length=99980)
         try:
             async with self.bot.http_session.post(
-                "https://paste.pythondiscord.com/documents", data=self.shorten_output(output, max_length=99980), raise_for_status=True
+                "https://paste.pythondiscord.com/documents", data=data, raise_for_status=True
             ) as resp:
                 data = await resp.json()
 

--- a/bot/exts/core/internal_eval/_internal_eval.py
+++ b/bot/exts/core/internal_eval/_internal_eval.py
@@ -87,7 +87,7 @@ class InternalEval(commands.Cog):
         """Upload `internal eval` output to our pastebin and return the url."""
         try:
             async with self.bot.http_session.post(
-                "https://paste.pythondiscord.com/documents", data=output, raise_for_status=True
+                "https://paste.pythondiscord.com/documents", data=self.shorten_output(output, max_length=99980), raise_for_status=True
             ) as resp:
                 data = await resp.json()
 


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->

Close #990 


## Description
I have truncated the output using the shorten_output method, limit the output to be 99980* character.
(*) the reason why is it 99980 is there should be 20 charater in the end stating that the output was truncated, they are `\n[output truncated]`

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
