### PR TITLE
Allow latex command in data science and ai channel

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -112,6 +112,7 @@ class Channels(NamedTuple):
     bot_commands = 267659945086812160
     community_meta = 267659945086812160
     organisation = 551789653284356126
+    data_science_and_ai = 366673247892275221
     devlog = int(environ.get("CHANNEL_DEVLOG", 622895325144940554))
     dev_contrib = 635950537262759947
     mod_meta = 775412552795947058

--- a/bot/exts/fun/latex.py
+++ b/bot/exts/fun/latex.py
@@ -10,6 +10,8 @@ from PIL import Image
 from discord.ext import commands
 
 from bot.bot import Bot
+from bot.constants import Channels, WHITELISTED_CHANNELS
+from bot.utils.decorators import whitelist_override
 
 FORMATTED_CODE_REGEX = re.compile(
     r"(?P<delim>(?P<block>```)|``?)"        # code delimiter: 1-3 backticks; (?P=block) only matches if it's a block
@@ -30,6 +32,10 @@ CACHE_DIRECTORY.mkdir(exist_ok=True)
 TEMPLATE = string.Template(Path("bot/resources/fun/latex_template.txt").read_text())
 
 PAD = 10
+
+LATEX_ALLOWED_CHANNNELS = WHITELISTED_CHANNELS + (
+    Channels.data_science_and_ai,
+)
 
 
 def _prepare_input(text: str) -> str:
@@ -97,6 +103,7 @@ class Latex(commands.Cog):
 
     @commands.command()
     @commands.max_concurrency(1, commands.BucketType.guild, wait=True)
+    @whitelist_override(channels=LATEX_ALLOWED_CHANNNELS)
     async def latex(self, ctx: commands.Context, *, query: str) -> None:
         """Renders the text in latex and sends the image."""
         query = _prepare_input(query)


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Allows the latex command to be ran in the data science and AI channel, as this is the place most likely to want a latex command. More channels can be added to the tuple after this PR as needed.

Here it is in action (where I have used the dev-core-contrib channel in my test server in place of the data science and ai channnel)
![image](https://user-images.githubusercontent.com/9753350/170455597-a15178d9-12d6-4d8f-afad-7a9351125b30.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
