### PR TITLE
Help: remove redundant space in subcommand aliases

### DIFF
--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -306,7 +306,7 @@ class HelpSession:
         signature = self._get_command_params(self.query)
         parent = self.query.full_parent_name + " " if self.query.parent else ""
         paginator.add_line(f"**```\n{prefix}{parent}{signature}\n```**")
-        aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in self.query.aliases]
+        aliases = [f"`{alias}`" if not parent else f"`{parent}{alias}`" for alias in self.query.aliases]
         aliases += [f"`{alias}`" for alias in getattr(self.query, "root_aliases", ())]
         aliases = ", ".join(sorted(aliases))
         if aliases:


### PR DESCRIPTION
## Relevant Issues

Fixes GH-1065. 

## Description

`parent` already has a trailing space so let's not add *another* one.

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
