### PR TITLE
Update .uwu to work with replies

### DIFF
--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -1,7 +1,9 @@
 import random
 import re
+import typing as t
 from functools import partial
 
+import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Context, clean_content
 
@@ -105,7 +107,7 @@ class Uwu(Cog):
         return input_string
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
-    async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:
+    async def uwu_command(self, ctx: Context, *, text: t.Optional[str] = None) -> None:
         """
         Echo an uwuified version the passed text.
 
@@ -113,7 +115,17 @@ class Uwu(Cog):
         '.uwu Hello, my name is John' returns something like
         'hewwo, m-my name is j-john nyaa~'.
         """
-        if (fun_cog := ctx.bot.get_cog("Fun")):
+        # If `text` isn't provided then we try to get message content of a replied message
+        if not text:
+            if reference := ctx.message.reference:
+                if isinstance((resolved_message := reference.resolved), discord.Message):
+                    text = resolved_message.content
+            # If we weren't able to get the content of a replied message
+            if text is None:
+                await ctx.send(content="Your message must have content or you must reply to a message.")
+                return
+
+        if fun_cog := ctx.bot.get_cog("Fun"):
             text, embed = await fun_cog._get_text_and_embed(ctx, text)
 
             # Grabs the text from the embed for uwuification.

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import discord
 from discord.ext import commands
-from discord.ext.commands import Cog, Context, clean_content
+from discord.ext.commands import Cog, Context
 
 from bot.bot import Bot
 from bot.utils import helpers

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -116,14 +116,10 @@ class Uwu(Cog):
         'hewwo, m-my name is j-john nyaa~'.
         """
         # If `text` isn't provided then we try to get message content of a replied message
-        if not text:
-            if reference := ctx.message.reference:
-                if isinstance((resolved_message := reference.resolved), discord.Message):
-                    text = resolved_message.content
+        text = text or getattr(ctx.message.reference, "resolved", None)
+        if text is None:
             # If we weren't able to get the content of a replied message
-            if text is None:
-                await ctx.send(content="Your message must have content or you must reply to a message.")
-                return
+            raise commands.UserInputError("Your message must have content or you must reply to a message.")
 
         if fun_cog := ctx.bot.get_cog("Fun"):
             text, embed = await fun_cog._get_text_and_embed(ctx, text)

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -3,6 +3,7 @@ import re
 import typing as t
 from functools import partial
 
+import discord
 from discord.ext import commands
 from discord.ext.commands import Cog, Context, clean_content
 
@@ -116,6 +117,9 @@ class Uwu(Cog):
         """
         # If `text` isn't provided then we try to get message content of a replied message
         text = text or getattr(ctx.message.reference, "resolved", None)
+        if isinstance(text, discord.Message):
+            text = text.content
+
         if text is None:
             # If we weren't able to get the content of a replied message
             raise commands.UserInputError("Your message must have content or you must reply to a message.")

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -3,9 +3,8 @@ import re
 import typing as t
 from functools import partial
 
-import discord
 from discord.ext import commands
-from discord.ext.commands import Cog, Context
+from discord.ext.commands import Cog, Context, clean_content
 
 from bot.bot import Bot
 from bot.utils import helpers
@@ -120,6 +119,8 @@ class Uwu(Cog):
         if text is None:
             # If we weren't able to get the content of a replied message
             raise commands.UserInputError("Your message must have content or you must reply to a message.")
+
+        await clean_content(fix_channel_mentions=True).convert(ctx, text)
 
         if fun_cog := ctx.bot.get_cog("Fun"):
             text, embed = await fun_cog._get_text_and_embed(ctx, text)


### PR DESCRIPTION
## Relevant Issues

Fixes #1069 


## Description

Updates `.uwu` to check for content in a replied to message if the current message is empty.

![image](https://user-images.githubusercontent.com/54628770/178110684-dd89e287-caca-416b-8c5d-281b6dec9b64.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
