### PR TITLE
Avoidance of `KeyError` from `"draft"` key when pulling GitHub PR data.

### DIFF
--- a/bot/exts/utilities/githubinfo.py
+++ b/bot/exts/utilities/githubinfo.py
@@ -183,7 +183,7 @@ class GithubInfo(commands.Cog):
         if not issues:
             return
 
-        log.trace(f"Found {issues = }")
+        log.trace("Found %s", issues)
 
         if len(issues) > MAXIMUM_ISSUES:
             embed = discord.Embed(


### PR DESCRIPTION
Closes #928 

We want to ensure the information received from GitHub is not malformed.

Due to this, `FetchError` handling has been moved to `fetch_data` function, so no placeholder variables in returns need to be used.

`FetchError` is no longer a data class, but an actual error which inherets from `Exception`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
