### PR TITLE
Fix: .uwu incorrectly transforms emojis in their raw text form

### DIFF
--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -62,6 +62,8 @@ RE_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?")
 
 @dataclass(frozen=True, eq=True)
 class Emoji:
+    """Data class for an Emoji."""
+
     name: str
     uid: int
     animated: bool = False
@@ -125,7 +127,7 @@ class Uwu(Cog):
         return match_string
 
     def _ext_emoji_replace(self, input_string: str) -> str:
-        """Replaces external emojis with emoticons"""
+        """Replaces external emojis with emoticons."""
         groups = RE_EMOJI.findall(input_string)
         emojis = {Emoji.from_match(match) for match in groups}
         # Replace with random emoticon if unable to display

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -57,7 +57,7 @@ SUBSTITUTE_STUTTER = r"\g<1>\g<2>-\g<2>"
 REGEX_NYA = re.compile(r"n([aeou][^aeiou])")
 SUBSTITUTE_NYA = r"ny\1"
 
-REGEX_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?")
+REGEX_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?", re.ASCII)
 
 
 @dataclass(frozen=True, eq=True)
@@ -79,7 +79,7 @@ class Emoji:
     @classmethod
     def from_match(cls, match: tuple[str, str, str]) -> t.Optional['Emoji']:
         """Creates an Emoji from a regex match tuple."""
-        if not match or len(match) != 3 or not match[2].isdigit():
+        if not match or len(match) != 3 or not match[2].isdecimal():
             return None
         return cls(match[1], int(match[2]), match[0] == "a")
 

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -128,7 +128,7 @@ class Uwu(Cog):
 
     def _ext_emoji_replace(self, input_string: str) -> str:
         """Replaces external emojis with emoticons."""
-        groups = RE_EMOJI.findall(input_string)
+        groups = REGEX_EMOJI.findall(input_string)
         emojis = {Emoji.from_match(match) for match in groups}
         # Replace with random emoticon if unable to display
         emojis_map = {

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -46,7 +46,7 @@ EMOJIS = [
     "^^;;",
 ]
 
-REGEX_WORD_REPLACE = re.compile(r"(?<![w])[lr](?![w])")
+REGEX_WORD_REPLACE = re.compile(r"(?<!w)[lr](?!w)")
 
 REGEX_PUNCTUATION = re.compile(r"[.!?\r\n\t]")
 

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -57,7 +57,7 @@ SUBSTITUTE_STUTTER = r"\g<1>\g<2>-\g<2>"
 REGEX_NYA = re.compile(r"n([aeou][^aeiou])")
 SUBSTITUTE_NYA = r"ny\1"
 
-REGEX_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?", re.ASCII)
+REGEX_EMOJI = re.compile(r"<(a)?:(\w+?):(\d{15,21}?)>", re.ASCII)
 
 
 @dataclass(frozen=True, eq=True)

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -10,6 +10,9 @@ from discord.ext.commands import Cog, Context, clean_content
 from bot.bot import Bot
 from bot.utils import helpers
 
+if t.TYPE_CHECKING:
+    from bot.exts.fun.fun import Fun  # pragma: no cover
+
 WORD_REPLACE = {
     "small": "smol",
     "cute": "kawaii~",
@@ -126,7 +129,8 @@ class Uwu(Cog):
 
         await clean_content(fix_channel_mentions=True).convert(ctx, text)
 
-        if fun_cog := ctx.bot.get_cog("Fun"):
+        fun_cog: t.Optional[Fun] = ctx.bot.get_cog("Fun")
+        if fun_cog:
             text, embed = await fun_cog._get_text_and_embed(ctx, text)
 
             # Grabs the text from the embed for uwuification.

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -57,7 +57,7 @@ SUBSTITUTE_STUTTER = r"\g<1>\g<2>-\g<2>"
 REGEX_NYA = re.compile(r"n([aeou][^aeiou])")
 SUBSTITUTE_NYA = r"ny\1"
 
-RE_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?")
+REGEX_EMOJI = re.compile(r"<(a?)?:(\w+):(\d{18})>?")
 
 
 @dataclass(frozen=True, eq=True)

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -127,7 +127,7 @@ class Uwu(Cog):
         return match_string
 
     def _ext_emoji_replace(self, input_string: str) -> str:
-        """Replaces external emojis with emoticons."""
+        """Replaces any emoji the bot cannot send in input_text with a random emoticons."""
         groups = REGEX_EMOJI.findall(input_string)
         emojis = {Emoji.from_match(match) for match in groups}
         # Replace with random emoticon if unable to display


### PR DESCRIPTION
## Relevant Issues
Fixes #1072

## Description
6db84b38568d3f53c1b1bec4c66c1c8f2ee7b1ac
- Added pattern `REGEX_EMOJI` to capture emoji markdowns
- Implemented `Emoji` data class for emoji information and displayability inferencing
- Added function `_ext_emoji_replace` to replace external undisplayable emojis with random emoticons
- Added call to `_ext_emoji_replace` at the end of `_uwuify`

## Fixes / formatting
202d53b3f7ebe4d6041a2e5a4c1419bc16b27e11
- Added type checking annotations for `fun_cog` using `typing.TYPE_CHECKING`

21194a8817ee34229a211f6f5aae8978d054a884
- Replaced a redundant single-letter regex character class with the character itself


## Example
- Built-in emojis and emojis the bot is able to display (due to sharing a server) are returned normally.
- For external undisplayable emojis, the bot correctly replaces it with a random emoticon from the `EMOJIS` list.

![Example](https://cdn.ionite.io/img/aiYZZI.jpg)




## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
