### PR TITLE
Fix issue with .uwu failing to uwuify embeds in replies

### DIFF
--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -3,16 +3,16 @@ import logging
 import random
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Callable, Literal, Optional, Union
+from typing import Literal
 
 import pyjokes
-from discord import Embed, Message
+from discord import Embed
 from discord.ext import commands
-from discord.ext.commands import BadArgument, Cog, Context, MessageConverter, clean_content
+from discord.ext.commands import BadArgument, Cog, Context, clean_content
 
 from bot.bot import Bot
 from bot.constants import Client, Colours, Emojis
-from bot.utils import helpers
+from bot.utils import helpers, messages
 
 log = logging.getLogger(__name__)
 
@@ -67,10 +67,10 @@ class Fun(Cog):
             return "".join(
                 char.upper() if round(random.random()) else char.lower() for char in text
             )
-        text, embed = await Fun._get_text_and_embed(ctx, text)
+        text, embed = await messages.get_text_and_embed(ctx, text)
         # Convert embed if it exists
         if embed is not None:
-            embed = Fun._convert_embed(conversion_func, embed)
+            embed = messages.convert_embed(conversion_func, embed)
         converted_text = conversion_func(text)
         converted_text = helpers.suppress_links(converted_text)
         # Don't put >>> if only embed present
@@ -116,10 +116,10 @@ class Fun(Cog):
             """Encrypts the given string using the Caesar Cipher."""
             return "".join(caesar_cipher(text, offset))
 
-        text, embed = await Fun._get_text_and_embed(ctx, msg)
+        text, embed = await messages.get_text_and_embed(ctx, msg)
 
         if embed is not None:
-            embed = Fun._convert_embed(conversion_func, embed)
+            embed = messages.convert_embed(conversion_func, embed)
 
         converted_text = conversion_func(text)
 
@@ -149,68 +149,6 @@ class Fun(Cog):
         Also accepts a valid Discord Message ID or link.
         """
         await self._caesar_cipher(ctx, offset, msg, left_shift=True)
-
-    @staticmethod
-    async def _get_text_and_embed(ctx: Context, text: str) -> tuple[str, Optional[Embed]]:
-        """
-        Attempts to extract the text and embed from a possible link to a discord Message.
-
-        Does not retrieve the text and embed from the Message if it is in a channel the user does
-        not have read permissions in.
-
-        Returns a tuple of:
-            str: If `text` is a valid discord Message, the contents of the message, else `text`.
-            Optional[Embed]: The embed if found in the valid Message, else None
-        """
-        embed = None
-
-        msg = await Fun._get_discord_message(ctx, text)
-        # Ensure the user has read permissions for the channel the message is in
-        if isinstance(msg, Message):
-            permissions = msg.channel.permissions_for(ctx.author)
-            if permissions.read_messages:
-                text = msg.clean_content
-                # Take first embed because we can't send multiple embeds
-                if msg.embeds:
-                    embed = msg.embeds[0]
-
-        return (text, embed)
-
-    @staticmethod
-    async def _get_discord_message(ctx: Context, text: str) -> Union[Message, str]:
-        """
-        Attempts to convert a given `text` to a discord Message object and return it.
-
-        Conversion will succeed if given a discord Message ID or link.
-        Returns `text` if the conversion fails.
-        """
-        try:
-            text = await MessageConverter().convert(ctx, text)
-        except commands.BadArgument:
-            log.debug(f"Input '{text:.20}...' is not a valid Discord Message")
-        return text
-
-    @staticmethod
-    def _convert_embed(func: Callable[[str, ], str], embed: Embed) -> Embed:
-        """
-        Converts the text in an embed using a given conversion function, then return the embed.
-
-        Only modifies the following fields: title, description, footer, fields
-        """
-        embed_dict = embed.to_dict()
-
-        embed_dict["title"] = func(embed_dict.get("title", ""))
-        embed_dict["description"] = func(embed_dict.get("description", ""))
-
-        if "footer" in embed_dict:
-            embed_dict["footer"]["text"] = func(embed_dict["footer"].get("text", ""))
-
-        if "fields" in embed_dict:
-            for field in embed_dict["fields"]:
-                field["name"] = func(field.get("name", ""))
-                field["value"] = func(field.get("value", ""))
-
-        return Embed.from_dict(embed_dict)
 
     @commands.command()
     async def joke(self, ctx: commands.Context, category: Literal["neutral", "chuck", "all"] = "all") -> None:

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -10,6 +10,9 @@ from discord.ext.commands import Cog, Context, clean_content
 from bot.bot import Bot
 from bot.utils import helpers
 
+if t.TYPE_CHECKING:
+    from bot.exts.fun.fun import Fun  # pragma: no cover
+
 WORD_REPLACE = {
     "small": "smol",
     "cute": "kawaii~",
@@ -129,7 +132,8 @@ class Uwu(Cog):
 
         await clean_content(fix_channel_mentions=True).convert(ctx, text)
 
-        fun_cog = ctx.bot.get_cog("Fun")
+        fun_cog: t.Optional[Fun] = ctx.bot.get_cog("Fun")
+
         if fun_cog:
             text, embed = await fun_cog._get_text_and_embed(ctx, text)
 

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -11,9 +11,6 @@ from discord.ext.commands import Cog, Context, clean_content
 from bot.bot import Bot
 from bot.utils import helpers, messages
 
-if t.TYPE_CHECKING:
-    from bot.exts.fun.fun import Fun  # pragma: no cover
-
 WORD_REPLACE = {
     "small": "smol",
     "cute": "kawaii~",
@@ -180,21 +177,16 @@ class Uwu(Cog):
 
         await clean_content(fix_channel_mentions=True).convert(ctx, text)
 
-        fun_cog: t.Optional[Fun] = ctx.bot.get_cog("Fun")
-
-        if fun_cog:
-            # Grabs the text from the embed for uwuification
-            if embeds:
-                embed = messages.convert_embed(self._uwuify, embeds[0])
-            else:
-                # Parse potential message links in text
-                text, embed = await messages.get_text_and_embed(ctx, text)
-
-                # If an embed is found, grab and uwuify its text
-                if embed:
-                    embed = messages.convert_embed(self._uwuify, embed)
+        # Grabs the text from the embed for uwuification
+        if embeds:
+            embed = messages.convert_embed(self._uwuify, embeds[0])
         else:
-            embed = None
+            # Parse potential message links in text
+            text, embed = await messages.get_text_and_embed(ctx, text)
+
+            # If an embed is found, grab and uwuify its text
+            if embed:
+                embed = messages.convert_embed(self._uwuify, embed)
 
         # Adds the text harvested from an embed to be put into another quote block.
         if text:

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -183,22 +183,23 @@ class Uwu(Cog):
         fun_cog: t.Optional[Fun] = ctx.bot.get_cog("Fun")
 
         if fun_cog:
-            text, embed = await fun_cog._get_text_and_embed(ctx, text)
-
             # Grabs the text from the embed for uwuification
-            if embed is not None:
-                embed = fun_cog._convert_embed(self._uwuify, embed)
+            if embeds:
+                embed = fun_cog._convert_embed(self._uwuify, embeds[0])
             else:
-                # Only use the first embed since only a single one can be sent
-                embed = fun_cog._convert_embed(self._uwuify, embeds[0]) if embeds else None
+                # Parse potential message links in text
+                text, embed = await fun_cog._get_text_and_embed(ctx, text)
+
+                # If an embed is found, grab and uwuify its text
+                if embed:
+                    embed = fun_cog._convert_embed(self._uwuify, embed)
         else:
             embed = None
 
-        converted_text = self._uwuify(text)
-        converted_text = helpers.suppress_links(converted_text)
-
         # Adds the text harvested from an embed to be put into another quote block.
         if text:
+            converted_text = self._uwuify(text)
+            converted_text = helpers.suppress_links(converted_text)
             converted_text = f">>> {converted_text.lstrip('> ')}"
         else:
             converted_text = None

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from discord.ext.commands import Cog, Context, clean_content
 
 from bot.bot import Bot
-from bot.utils import helpers
+from bot.utils import helpers, messages
 
 if t.TYPE_CHECKING:
     from bot.exts.fun.fun import Fun  # pragma: no cover
@@ -185,14 +185,14 @@ class Uwu(Cog):
         if fun_cog:
             # Grabs the text from the embed for uwuification
             if embeds:
-                embed = fun_cog._convert_embed(self._uwuify, embeds[0])
+                embed = messages.convert_embed(self._uwuify, embeds[0])
             else:
                 # Parse potential message links in text
-                text, embed = await fun_cog._get_text_and_embed(ctx, text)
+                text, embed = await messages.get_text_and_embed(ctx, text)
 
                 # If an embed is found, grab and uwuify its text
                 if embed:
-                    embed = fun_cog._convert_embed(self._uwuify, embed)
+                    embed = messages.convert_embed(self._uwuify, embed)
         else:
             embed = None
 

--- a/bot/exts/fun/uwu.py
+++ b/bot/exts/fun/uwu.py
@@ -126,19 +126,19 @@ class Uwu(Cog):
         if text is None:
             # If we weren't able to get the content of a replied message
             raise commands.UserInputError("Your message must have content or you must reply to a message.")
-        
+
         await clean_content(fix_channel_mentions=True).convert(ctx, text)
-        
+
         fun_cog = ctx.bot.get_cog("Fun")
         if fun_cog:
             text, embed = await fun_cog._get_text_and_embed(ctx, text)
-            
+
             # Grabs the text from the embed for uwuification
             if embed is not None:
                 embed = fun_cog._convert_embed(self._uwuify, embed)
             else:
                 # Only use the first embed since only a single one can be sent
-                embed = fun_cog._convert_embed(self._uwuify, embeds[0]) if embeds else None 
+                embed = fun_cog._convert_embed(self._uwuify, embeds[0]) if embeds else None
         else:
             embed = None
 

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -3,6 +3,7 @@ import re
 from typing import Callable, Optional, Union
 
 from discord import Embed, Message
+from discord.ext import commands
 from discord.ext.commands import Context, MessageConverter
 
 log = logging.getLogger(__name__)
@@ -32,7 +33,10 @@ async def get_discord_message(ctx: Context, text: str) -> Union[Message, str]:
     Conversion will succeed if given a discord Message ID or link.
     Returns `text` if the conversion fails.
     """
-    text = await MessageConverter().convert(ctx, text)
+    try:
+        text = await MessageConverter().convert(ctx, text)
+    except commands.BadArgument:
+        pass
 
     return text
 

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -3,7 +3,6 @@ import re
 from typing import Callable, Optional, Union
 
 from discord import Embed, Message
-from discord.ext import commands
 from discord.ext.commands import Context, MessageConverter
 
 log = logging.getLogger(__name__)
@@ -33,10 +32,7 @@ async def get_discord_message(ctx: Context, text: str) -> Union[Message, str]:
     Conversion will succeed if given a discord Message ID or link.
     Returns `text` if the conversion fails.
     """
-    try:
-        text = await MessageConverter().convert(ctx, text)
-    except commands.BadArgument:
-        log.debug(f"Input '{text:.20}...' is not a valid Discord Message")
+    text = await MessageConverter().convert(ctx, text)
 
     return text
 
@@ -64,7 +60,7 @@ async def get_text_and_embed(ctx: Context, text: str) -> tuple[str, Optional[Emb
             if msg.embeds:
                 embed = msg.embeds[0]
 
-    return (text, embed)
+    return text, embed
 
 
 def convert_embed(func: Callable[[str, ], str], embed: Embed) -> Embed:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -1,5 +1,12 @@
+import logging
 import re
-from typing import Optional
+from typing import Callable, Optional, Union
+
+from discord import Embed, Message
+from discord.ext import commands
+from discord.ext.commands import Context, MessageConverter
+
+log = logging.getLogger(__name__)
 
 
 def sub_clyde(username: Optional[str]) -> Optional[str]:
@@ -17,3 +24,66 @@ def sub_clyde(username: Optional[str]) -> Optional[str]:
         return re.sub(r"(clyd)(e)", replace_e, username, flags=re.I)
     else:
         return username  # Empty string or None
+
+
+async def get_discord_message(ctx: Context, text: str) -> Union[Message, str]:
+    """
+    Attempts to convert a given `text` to a discord Message object and return it.
+
+    Conversion will succeed if given a discord Message ID or link.
+    Returns `text` if the conversion fails.
+    """
+    try:
+        text = await MessageConverter().convert(ctx, text)
+    except commands.BadArgument:
+        log.debug(f"Input '{text:.20}...' is not a valid Discord Message")
+
+    return text
+
+
+async def get_text_and_embed(ctx: Context, text: str) -> tuple[str, Optional[Embed]]:
+    """
+    Attempts to extract the text and embed from a possible link to a discord Message.
+
+    Does not retrieve the text and embed from the Message if it is in a channel the user does
+    not have read permissions in.
+
+    Returns a tuple of:
+        str: If `text` is a valid discord Message, the contents of the message, else `text`.
+        Optional[Embed]: The embed if found in the valid Message, else None
+    """
+    embed: Optional[Embed] = None
+
+    msg = await get_discord_message(ctx, text)
+    # Ensure the user has read permissions for the channel the message is in
+    if isinstance(msg, Message):
+        permissions = msg.channel.permissions_for(ctx.author)
+        if permissions.read_messages:
+            text = msg.clean_content
+            # Take first embed because we can't send multiple embeds
+            if msg.embeds:
+                embed = msg.embeds[0]
+
+    return (text, embed)
+
+
+def convert_embed(func: Callable[[str, ], str], embed: Embed) -> Embed:
+    """
+    Converts the text in an embed using a given conversion function, then return the embed.
+
+    Only modifies the following fields: title, description, footer, fields
+    """
+    embed_dict = embed.to_dict()
+
+    embed_dict["title"] = func(embed_dict.get("title", ""))
+    embed_dict["description"] = func(embed_dict.get("description", ""))
+
+    if "footer" in embed_dict:
+        embed_dict["footer"]["text"] = func(embed_dict["footer"].get("text", ""))
+
+    if "fields" in embed_dict:
+        for field in embed_dict["fields"]:
+            field["name"] = func(field.get("name", ""))
+            field["value"] = func(field.get("value", ""))
+
+    return Embed.from_dict(embed_dict)


### PR DESCRIPTION
## Relevant Issues
Closes #1075
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
In `uwu_command`, if command was invoked referring to a replied message, store the message's embeds in an `embeds` variable, otherwise set it to `None`.
Add an `else` statement in `uwu_command` after `if embed is not None` to fallback to `embeds` which was defined earlier.
Add a check in `uwu_command` to avoid adding a leading `>>>` if the uwuified content contains only an embed.

![image](https://user-images.githubusercontent.com/67297584/179435609-fe0d7e92-abc5-4c9d-811e-705b2025cecd.png)
![image](https://user-images.githubusercontent.com/67297584/179435628-7eb9edbb-b42d-4c59-914f-e92261d345e3.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
