### PR TITLE
Add 1<<15 to the raw intents value

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -13,4 +13,7 @@ for ext in walk_extensions():
     bot.load_extension(ext)
 
 if not Client.in_ci:
+    # Manually enable the message content intent. This is required until the below PR is merged
+    # https://github.com/python-discord/sir-lancebot/pull/1092
+    bot._connection._intents.value += 1 << 15
     bot.run(Client.token)


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
1<<15 is the flag for message content intent, so adding this value to the intents value hard codes that to always be enabled.

Doing it this way also bypasses the need to patch the flags themselvse in discord.py.

This is required until https://github.com/python-discord/sir-lancebot/pull/1092 is merged.
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [ ] Join the [**Python Discord Community**](https://discord.gg/python)?
- [ ] Read all the comments in this template?
- [ ] Ensure there is an issue open, or link relevant discord discussions?
- [ ] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
