### PR TITLE
Fix issue #1050

### DIFF
--- a/bot/exts/holidays/halloween/spookygif.py
+++ b/bot/exts/holidays/halloween/spookygif.py
@@ -25,7 +25,7 @@ class SpookyGif(commands.Cog):
             # Make a GET request to the Giphy API to get a random halloween gif.
             async with self.bot.http_session.get(API_URL, params=params) as resp:
                 data = await resp.json()
-            url = data["data"]["images"]["original"]["url"]
+            url = data["data"]["images"]["downsized"]["url"]
 
             embed = discord.Embed(title="A spooooky gif!", colour=Colours.purple)
             embed.set_image(url=url)


### PR DESCRIPTION
> Corrects key values for Giphy API response in .spookygif command
> 
> ## Relevant Issues
> #1050
> 
> ## Description
> Made the following change to line 28 of bot/exts/holidays/halloween/spookygif.py
> 
> ```diff
> -url = data["data"]["image_url"]
> +url = data["data"]["images"]["original"]["url"]
> ```
> 
> ## Did you:
> * [x]  Join the [**Python Discord Community**](https://discord.gg/python)?
> * [x]  Read all the comments in this template?
> * [x]  Ensure there is an issue open, or link relevant discord discussions?
> * [x]  Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?

