### PR TITLE
Fix position-only arg in hangman & madlibs command.

### DIFF
--- a/bot/exts/fun/hangman.py
+++ b/bot/exts/fun/hangman.py
@@ -110,7 +110,7 @@ class Hangman(commands.Cog):
 
             try:
                 message = await self.bot.wait_for(
-                    event="message",
+                    "message",
                     timeout=60.0,
                     check=check
                 )

--- a/bot/exts/fun/madlibs.py
+++ b/bot/exts/fun/madlibs.py
@@ -93,7 +93,7 @@ class Madlibs(commands.Cog):
             await original_message.edit(embed=madlibs_embed)
 
             try:
-                message = await self.bot.wait_for(event="message", check=author_check, timeout=TIMEOUT)
+                message = await self.bot.wait_for("message", check=author_check, timeout=TIMEOUT)
             except TimeoutError:
                 timeout_embed = discord.Embed(
                     title=choice(NEGATIVE_REPLIES),


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #1106.

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
As the title says. `Client.wait_for` is now a positional-only arg, so adjusted as such to fix the games (tested and both games do now work).

![hangman](https://user-images.githubusercontent.com/47674925/193455791-d441b7fd-6644-48b5-ac86-e2800e365e46.png)
![madlibs](https://user-images.githubusercontent.com/47674925/193456307-50de5899-d3b0-4247-a61c-55566113a577.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
