### PR TITLE
Fix order of function parameters on @discord.ui.select

### DIFF
--- a/bot/exts/events/advent_of_code/views/dayandstarview.py
+++ b/bot/exts/events/advent_of_code/views/dayandstarview.py
@@ -69,7 +69,7 @@ class AoCDropdownView(discord.ui.View):
         self.star = select.values[0]
 
     @discord.ui.button(label="Fetch", style=discord.ButtonStyle.blurple)
-    async def fetch(self, _: discord.ui.Button, interaction: discord.Interaction) -> None:
+    async def fetch(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
         """Button that fetches the statistics based on the dropdown values."""
         if self.day == 0 or self.star == 0:
             await interaction.response.send_message(

--- a/bot/exts/events/advent_of_code/views/dayandstarview.py
+++ b/bot/exts/events/advent_of_code/views/dayandstarview.py
@@ -55,7 +55,7 @@ class AoCDropdownView(discord.ui.View):
         options=[discord.SelectOption(label=str(i)) for i in range(1, 26)],
         custom_id="day_select"
     )
-    async def day_select(self, select: discord.ui.Select, interaction: discord.Interaction) -> None:
+    async def day_select(self, _: discord.Interaction, select: discord.ui.Select) -> None:
         """Dropdown to choose a Day of the AoC."""
         self.day = select.values[0]
 
@@ -64,12 +64,12 @@ class AoCDropdownView(discord.ui.View):
         options=[discord.SelectOption(label=str(i)) for i in range(1, 3)],
         custom_id="star_select"
     )
-    async def star_select(self, select: discord.ui.Select, interaction: discord.Interaction) -> None:
+    async def star_select(self, _: discord.Interaction, select: discord.ui.Select) -> None:
         """Dropdown to choose either the first or the second star."""
         self.star = select.values[0]
 
     @discord.ui.button(label="Fetch", style=discord.ButtonStyle.blurple)
-    async def fetch(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+    async def fetch(self, _: discord.ui.Button, interaction: discord.Interaction) -> None:
         """Button that fetches the statistics based on the dropdown values."""
         if self.day == 0 or self.star == 0:
             await interaction.response.send_message(

--- a/bot/exts/events/trivianight/_scoreboard.py
+++ b/bot/exts/events/trivianight/_scoreboard.py
@@ -128,7 +128,7 @@ class ScoreboardView(View):
         Send an ephemeral message with the speed leaderboard embed.
 
         Parameters:
-             - interaction: The discord.Interaction instance containing information on the interaction between the user
+            - interaction: The discord.Interaction instance containing information on the interaction between the user
             and the button.
             - button: The discord.ui.Button instance representing the `Speed Leaderboard` button.
         """

--- a/bot/exts/events/trivianight/_scoreboard.py
+++ b/bot/exts/events/trivianight/_scoreboard.py
@@ -123,26 +123,26 @@ class ScoreboardView(View):
         return rank_embed
 
     @discord.ui.button(label="Scoreboard for Speed", style=ButtonStyle.green)
-    async def speed_leaderboard(self, button: Button, interaction: Interaction) -> None:
+    async def speed_leaderboard(self, interaction: Interaction, _: Button) -> None:
         """
         Send an ephemeral message with the speed leaderboard embed.
 
         Parameters:
-            - button: The discord.ui.Button instance representing the `Speed Leaderboard` button.
-            - interaction: The discord.Interaction instance containing information on the interaction between the user
+             - interaction: The discord.Interaction instance containing information on the interaction between the user
             and the button.
+            - button: The discord.ui.Button instance representing the `Speed Leaderboard` button.
         """
         await interaction.response.send_message(embed=await self._create_speed_embed(), ephemeral=True)
 
     @discord.ui.button(label="What's my rank?", style=ButtonStyle.blurple)
-    async def rank_button(self, button: Button, interaction: Interaction) -> None:
+    async def rank_button(self, interaction: Interaction, _: Button) -> None:
         """
         Send an ephemeral message with the user's rank for the overall points/average speed.
 
         Parameters:
-            - button: The discord.ui.Button instance representing the `What's my rank?` button.
             - interaction: The discord.Interaction instance containing information on the interaction between the user
             and the button.
+            - button: The discord.ui.Button instance representing the `What's my rank?` button.
         """
         await interaction.response.send_message(embed=self._get_rank(interaction.user), ephemeral=True)
 

--- a/bot/exts/utilities/epoch.py
+++ b/bot/exts/utilities/epoch.py
@@ -119,7 +119,7 @@ class TimestampMenuView(discord.ui.View):
             self.dropdown.add_option(label=label, description=date_time)
 
     @discord.ui.select(placeholder="Select the format of your timestamp")
-    async def select_format(self, _: discord.ui.Select, interaction: discord.Interaction) -> discord.Message:
+    async def select_format(self, interaction: discord.Interaction, _: discord.ui.Select) -> discord.Message:
         """Drop down menu which contains a list of formats which discord timestamps can take."""
         selected = interaction.data["values"][0]
         if selected == "Epoch":


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #1108.

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
During development of dpy 2.0, the order of the `interaction` and `select` swapped, but this wasn't updated in the codebase. This PR fixes that in the 3 use-cases of the `@discord.ui.select` decorator.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
