### PR TITLE
Fix hacktoberfest-issues bug

### DIFF
--- a/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
+++ b/bot/exts/events/hacktoberfest/hacktober-issue-finder.py
@@ -100,8 +100,9 @@ class HacktoberIssues(commands.Cog):
         """Format the issue data into a embed."""
         title = issue["title"]
         issue_url = issue["url"].replace("api.", "").replace("/repos/", "/")
-        # issues can have empty bodies, which in that case GitHub doesn't include the key in the API response
-        body = issue.get("body", "")
+        # Issues can have empty bodies, resulting in the value being a literal `null` (parsed as `None`).
+        # For this reason, we can't use the default arg of `dict.get`, and so instead use `or` logic.
+        body = issue.get("body") or ""
         labels = [label["name"] for label in issue["labels"]]
 
         embed = discord.Embed(title=title)


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
Closes #1107.

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
As described in the issue, the value of the `body` key returned by the API can be a literal `null` value, meaning `dict.get("body", "")` won't substitute as the key does exist. Instead, we now use `dict.get("body") or ""`.


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
