### PR TITLE
`REPO_TOKEN` is no more.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: python-discord/kubernetes
-          token: ${{ secrets.REPO_TOKEN }}
           path: kubernetes
 
       - name: Authenticate with Kubernetes


### PR DESCRIPTION
Solves part of https://github.com/python-discord/kubernetes/issues/140, since the repository is now public.