### PR TITLE
Make bookmark a context menu command

### DIFF
--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -138,7 +138,10 @@ class Bookmark(commands.Cog):
             log.info(f"{member} bookmarked {target_message.jump_url} with title '{title}'")
 
     @staticmethod
-    async def run_permission_check(author: discord.Member | discord.User, channel: discord.TextChannel) -> bool:
+    async def user_is_permitted_to_bookmark(
+            author: discord.Member | discord.User,
+            channel: discord.TextChannel
+    ) -> bool:
         """
         Check if users have the right to bookmark a message in a particular channel.
 
@@ -158,7 +161,7 @@ class Bookmark(commands.Cog):
 
     async def book_mark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
         """The callback that will be invoked upon using the bookmark's context menu command."""
-        if not await self.run_permission_check(interaction.user, message.channel):
+        if not await self.user_is_permitted_to_bookmark(interaction.user, message.channel):
             return
 
         title = "Bookmark"
@@ -189,7 +192,7 @@ class Bookmark(commands.Cog):
         if target_message is None:
             raise commands.UserInputError(MESSAGE_NOT_FOUND_ERROR)
 
-        if not await self.run_permission_check(ctx.author, target_message.channel):
+        if not await self.user_is_permitted_to_bookmark(ctx.author, target_message.channel):
             return
 
         await self.action_bookmark(ctx.channel, ctx.author, target_message, title)

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -30,15 +30,6 @@ class BookmarkTitleSelectionForm(discord.ui.Modal):
     This form is only available when the command is invoked from a context menu.
     """
 
-    def __init__(
-            self,
-            message: discord.Message,
-            action_bookmark_function: Callable[[discord.TextChannel, discord.Member, discord.Message, str], None],
-    ):
-        super().__init__(timeout=1000, title="Name your bookmark")
-        self.message = message
-        self.action_bookmark = action_bookmark_function
-
     bookmark_title = discord.ui.TextInput(
         label="Choose a title for you bookmark",
         placeholder="Type your bookmark title here",
@@ -47,6 +38,15 @@ class BookmarkTitleSelectionForm(discord.ui.Modal):
         min_length=0,
         required=False
     )
+
+    def __init__(
+            self,
+            message: discord.Message,
+            action_bookmark_function: Callable[[discord.TextChannel, discord.Member, discord.Message, str], None],
+    ):
+        super().__init__(timeout=1000, title="Name your bookmark")
+        self.message = message
+        self.action_bookmark = action_bookmark_function
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         """Sends the bookmark embed to the user with the newly chosen title."""

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -126,8 +126,8 @@ class Bookmark(commands.Cog):
         """Build the ephemeral embed to the bookmark requester."""
         return discord.Embed(
             description=(
-                f"A bookmark for [this message]({target_message.jump_url})"
-                f"has been successfully sent your way"
+                f"A bookmark for [this message]({target_message.jump_url}) "
+                f"has been successfully sent your way.\n"
                 f"Please check your DMs to retrieve it."
             ),
             colour=Colours.soft_green,

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -31,7 +31,7 @@ class BookmarkTitleSelectionForm(discord.ui.Modal):
     """
 
     bookmark_title = discord.ui.TextInput(
-        label="Choose a title for you bookmark",
+        label="Choose a title for you bookmark (optional)",
         placeholder="Type your bookmark title here",
         default="Bookmark",
         max_length=50,

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -128,7 +128,6 @@ class Bookmark(commands.Cog):
             description=(
                 f"A bookmark for [this message]({target_message.jump_url}) "
                 f"has been successfully sent your way.\n"
-                f"Please check your DMs to retrieve it."
             ),
             colour=Colours.soft_green,
         )

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -73,7 +73,7 @@ class Bookmark(commands.Cog):
         self.bot = bot
         self.book_mark_context_menu = discord.app_commands.ContextMenu(
             name="Bookmark",
-            callback=self.book_mark_context_menu_callback
+            callback=self._bookmark_context_menu_callback
         )
         self.bot.tree.add_command(self.book_mark_context_menu)
 
@@ -159,7 +159,7 @@ class Bookmark(commands.Cog):
             return False
         return True
 
-    async def book_mark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
+    async def _bookmark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
         """The callback that will be invoked upon using the bookmark's context menu command."""
         if not await self.user_is_permitted_to_bookmark(interaction.user, message.channel):
             return

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -77,20 +77,17 @@ class Bookmark(commands.Cog):
         )
         self.bot.tree.add_command(self.book_mark_context_menu)
 
-    async def cog_load(self) -> None:
-        """Carry out cog asynchronous initialisation."""
-        await self.bot.tree.sync()
-
     @staticmethod
     def build_bookmark_embed(target_message: discord.Message) -> discord.Embed:
         """Build the channel embed to the bookmark requester."""
-        return discord.Embed(
+        embed = discord.Embed(
             description=(
                 f"Click the button to be sent your very own bookmark to "
                 f"[this message]({target_message.jump_url})."
             ),
             colour=Colours.soft_green,
         )
+        return embed
 
     @staticmethod
     def build_bookmark_dm(target_message: discord.Message, title: str) -> discord.Embed:

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -82,7 +82,8 @@ class Bookmark(commands.Cog):
         await self.bot.tree.sync()
 
     @staticmethod
-    def build_bookmark_embed(target_message: discord.Message):
+    def build_bookmark_embed(target_message: discord.Message) -> discord.Embed:
+        """Build the channel embed to the bookmark requester."""
         return discord.Embed(
             description=(
                 f"Click the button to be sent your very own bookmark to "
@@ -137,8 +138,9 @@ class Bookmark(commands.Cog):
             log.info(f"{member} bookmarked {target_message.jump_url} with title '{title}'")
 
     @staticmethod
-    async def run_permission_check(author: discord.Member | discord.User, channel: discord.TextChannel):
-        """Check if users have the right to bookmark a message in a particular channel.
+    async def run_permission_check(author: discord.Member | discord.User, channel: discord.TextChannel) -> bool:
+        """
+        Check if users have the right to bookmark a message in a particular channel.
 
         This also notifies users in case they don't have the right to.
         """
@@ -154,7 +156,8 @@ class Bookmark(commands.Cog):
             return False
         return True
 
-    async def book_mark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message):
+    async def book_mark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
+        """The callback that will be invoked upon using the bookmark's context menu command."""
         if not await self.run_permission_check(interaction.user, message.channel):
             return
 
@@ -164,7 +167,6 @@ class Bookmark(commands.Cog):
         view = SendBookmark(self.action_bookmark, interaction.user, message.channel, message, title)
         embed = self.build_bookmark_embed(message)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
-
 
     @commands.group(name="bookmark", aliases=("bm", "pin"), invoke_without_command=True)
     @commands.guild_only()

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -71,6 +71,11 @@ class Bookmark(commands.Cog):
 
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.book_mark_context_menu = discord.app_commands.ContextMenu(
+            name="Bookmark",
+            callback=self.book_mark_context_menu_callback
+        )
+        self.bot.tree.add_command(self.book_mark_context_menu)
 
     async def cog_load(self) -> None:
         """Carry out cog asynchronous initialisation."""
@@ -148,6 +153,18 @@ class Bookmark(commands.Cog):
             await channel.send(embed=embed)
             return False
         return True
+
+    async def book_mark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message):
+        if not await self.run_permission_check(interaction.user, message.channel):
+            return
+
+        title = "Bookmark"
+        await self.action_bookmark(message.channel, interaction.user, message, title)
+
+        view = SendBookmark(self.action_bookmark, interaction.user, message.channel, message, title)
+        embed = self.build_bookmark_embed(message)
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
 
     @commands.group(name="bookmark", aliases=("bm", "pin"), invoke_without_command=True)
     @commands.guild_only()

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -52,9 +52,8 @@ class BookmarkTitleSelectionForm(discord.ui.Modal):
         """Sends the bookmark embed to the user with the newly chosen title."""
         title = self.bookmark_title.value or self.bookmark_title.default
         await self.action_bookmark(interaction.channel, interaction.user, self.message, title)
-        view = SendBookmark(self.action_bookmark, interaction.user, interaction.channel, self.message, title)
-        embed = Bookmark.build_bookmark_embed(self.message)
-        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+        embed = Bookmark.build_ephemeral_bookmark_embed(self.message)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 class LinkTargetMessage(discord.ui.View):
@@ -118,6 +117,18 @@ class Bookmark(commands.Cog):
             description=(
                 f"Click the button to be sent your very own bookmark to "
                 f"[this message]({target_message.jump_url})."
+            ),
+            colour=Colours.soft_green,
+        )
+
+    @staticmethod
+    def build_ephemeral_bookmark_embed(target_message: discord.Message) -> discord.Embed:
+        """Build the ephemeral embed to the bookmark requester."""
+        return discord.Embed(
+            description=(
+                f"A bookmark for [this message]({target_message.jump_url})"
+                f"has been successfully sent your way"
+                f"Please check your DMs to retrieve it."
             ),
             colour=Colours.soft_green,
         )

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -72,6 +72,10 @@ class Bookmark(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
+    async def cog_load(self) -> None:
+        """Carry out cog asynchronous initialisation."""
+        await self.bot.tree.sync()
+
     @staticmethod
     def build_bookmark_dm(target_message: discord.Message, title: str) -> discord.Embed:
         """Build the embed to DM the bookmark requester."""

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -114,14 +114,13 @@ class Bookmark(commands.Cog):
     @staticmethod
     def build_bookmark_embed(target_message: discord.Message) -> discord.Embed:
         """Build the channel embed to the bookmark requester."""
-        embed = discord.Embed(
+        return discord.Embed(
             description=(
                 f"Click the button to be sent your very own bookmark to "
                 f"[this message]({target_message.jump_url})."
             ),
             colour=Colours.soft_green,
         )
-        return embed
 
     @staticmethod
     def build_bookmark_dm(target_message: discord.Message, title: str) -> discord.Embed:

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -138,7 +138,7 @@ class Bookmark(commands.Cog):
         """The callback that will be invoked upon using the bookmark's context menu command."""
         permissions = interaction.channel.permissions_for(interaction.user)
         if not permissions.read_messages:
-            log.info(f"{interaction.user.author} tried to bookmark a message in #{interaction.channel}"
+            log.info(f"{interaction.user} tried to bookmark a message in #{interaction.channel}"
                      f"but has no permissions.")
             embed = Bookmark.build_error_embed("You don't have permission to view this channel.")
             await interaction.response.send_message(embed=embed)

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -77,6 +77,16 @@ class Bookmark(commands.Cog):
         await self.bot.tree.sync()
 
     @staticmethod
+    def build_bookmark_embed(target_message: discord.Message):
+        return discord.Embed(
+            description=(
+                f"Click the button to be sent your very own bookmark to "
+                f"[this message]({target_message.jump_url})."
+            ),
+            colour=Colours.soft_green,
+        )
+
+    @staticmethod
     def build_bookmark_dm(target_message: discord.Message, title: str) -> discord.Embed:
         """Build the embed to DM the bookmark requester."""
         embed = discord.Embed(
@@ -166,14 +176,8 @@ class Bookmark(commands.Cog):
         await self.action_bookmark(ctx.channel, ctx.author, target_message, title)
 
         view = SendBookmark(self.action_bookmark, ctx.author, ctx.channel, target_message, title)
+        embed = self.build_bookmark_embed(target_message)
 
-        embed = discord.Embed(
-            description=(
-                f"Click the button to be sent your very own bookmark to "
-                f"[this message]({target_message.jump_url})."
-            ),
-            colour=Colours.soft_green,
-        )
         await ctx.send(embed=embed, view=view)
 
     @bookmark.command(name="delete", aliases=("del", "rm"), root_aliases=("unbm", "unbookmark", "dmdelete", "dmdel"))

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -180,6 +180,11 @@ class Bookmark(commands.Cog):
     async def _bookmark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
         """The callback that will be invoked upon using the bookmark's context menu command."""
         permissions = interaction.channel.permissions_for(interaction.user)
+        if not interaction.channel.guild:
+            embed = Bookmark.build_error_embed("This command cannot be used in DMs.")
+            await interaction.response.send_message(embed=embed)
+            return
+
         if not permissions.read_messages:
             log.info(f"{interaction.user} tried to bookmark a message in #{interaction.channel}"
                      f"but has no permissions.")

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -136,7 +136,7 @@ class Bookmark(commands.Cog):
 
     async def _bookmark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
         """The callback that will be invoked upon using the bookmark's context menu command."""
-        permissions = interaction.channel.channel.permissions_for(interaction.user)
+        permissions = interaction.channel.permissions_for(interaction.user)
         if not permissions.read_messages:
             log.info(f"{interaction.user.author} tried to bookmark a message in #{interaction.channel}"
                      f"but has no permissions.")


### PR DESCRIPTION
**NOTE**
This needs to wait for [this PR](https://github.com/python-discord/bot-core/pull/171) before it can be merged, since it will be the one syncing the command tree.
Once that has been completed & merged, bot-core version needs to be bumped and then merged into main, then this branch will be updated

Closes #1089

This adds the support of bookmarking a message from a context menu, but preserves the old behavior as well.

To not lose the functionality of choosing a custom title, a modal has been added where a user is prompted for a title, which they can freely skip.

# Workflow
1. As usual, a user needs to identify a message to bookmark
![image](https://user-images.githubusercontent.com/48383734/209650705-0f1e4d9f-b947-4835-a0fc-e2349f8434d3.png)

2. A user hovers on the message, then clicks on the ellipsis (three dots) -> Apps -> Bookmark 
![image](https://user-images.githubusercontent.com/48383734/209651022-7d55ead9-41ce-4ee0-a186-56cde0b25c7e.png)

3. A user will be asked to choose a custom title for their bookmark, but they can freely ignore that step by clicking on `Submit` and the default title `Bookmark` will be chosen
![image](https://user-images.githubusercontent.com/48383734/209651404-d3d2c0aa-8e37-482f-85e1-1267c5b11dc9.png)

4. Once submitted, the bookmark is sent as usual as a DM to the user, the only difference is that the bookmark embed in the invoked channel is now **ephemeral**
![image](https://user-images.githubusercontent.com/48383734/209651580-6ae1bce8-9355-4425-b77e-7ce83a15d197.png)
![image](https://user-images.githubusercontent.com/48383734/209651601-73c541fa-e815-49c7-8065-ab0825293566.png)
