### PR TITLE
Move Earth Day Reactions from February to April

### DIFF
--- a/bot/exts/holidays/holidayreact.py
+++ b/bot/exts/holidays/holidayreact.py
@@ -37,7 +37,7 @@ Easter = Holiday([Month.APRIL], {
     "egg": Trigger(r"\begg\b", ["\U0001F95A"]),
     }
 )
-EarthDay = Holiday([Month.FEBRUARY], {
+EarthDay = Holiday([Month.APRIL], {
     "earth": Trigger(r"\b(earth|planet)\b", ["\U0001F30E", "\U0001F30D", "\U0001F30F"]),
     }
 )


### PR DESCRIPTION
## Relevant Issues
None. I asked in python-general whether I should make this an issue first, but godlygeek and zig suggested its size (+3 characters) makes that unnecessary.

## Description
I accidentally told Sir Lancebot that Earth Day was in February, meaning that it is currently (during February) reacting on `earth`. This PR moves it to April, where Earth Day resides on the 22nd.

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
