### PR TITLE
Deprecate bookmark text command

### DIFF
--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -106,9 +106,9 @@ class Bookmark(commands.Cog):
         self.bot = bot
         self.book_mark_context_menu = discord.app_commands.ContextMenu(
             name="Bookmark",
-            callback=self._bookmark_context_menu_callback
+            callback=self._bookmark_context_menu_callback,
         )
-        self.bot.tree.add_command(self.book_mark_context_menu)
+        self.bot.tree.add_command(self.book_mark_context_menu, guild=discord.Object(bot.guild_id))
 
     @staticmethod
     def build_bookmark_embed(target_message: discord.Message) -> discord.Embed:
@@ -180,11 +180,6 @@ class Bookmark(commands.Cog):
     async def _bookmark_context_menu_callback(self, interaction: discord.Interaction, message: discord.Message) -> None:
         """The callback that will be invoked upon using the bookmark's context menu command."""
         permissions = interaction.channel.permissions_for(interaction.user)
-        if not interaction.channel.guild:
-            embed = Bookmark.build_error_embed("This command cannot be used in DMs.")
-            await interaction.response.send_message(embed=embed)
-            return
-
         if not permissions.read_messages:
             log.info(f"{interaction.user} tried to bookmark a message in #{interaction.channel}"
                      f"but has no permissions.")

--- a/bot/exts/utilities/bookmark.py
+++ b/bot/exts/utilities/bookmark.py
@@ -57,16 +57,11 @@ class BookmarkForm(discord.ui.Modal):
         Raises ``discord.Forbidden`` if the user's DMs are closed.
         """
         embed = Bookmark.build_bookmark_dm(target_message, title)
-        await interaction.user.send(embed=embed, view=LinkTargetMessage(target_message))
+        message_url_view = discord.ui.View().add_item(
+            discord.ui.Button(label="View Message", url=target_message.jump_url)
+        )
+        await interaction.user.send(embed=embed, view=message_url_view)
         log.info(f"{interaction.user} bookmarked {target_message.jump_url} with title {title!r}")
-
-
-class LinkTargetMessage(discord.ui.View):
-    """The button that relays the user to the bookmarked message."""
-
-    def __init__(self, target_message: discord.Message):
-        super().__init__()
-        self.add_item(discord.ui.Button(label="View Message", url=target_message.jump_url))
 
 
 class Bookmark(commands.Cog):


### PR DESCRIPTION
## Description
<!-- Describe what changes you made, and how you've implemented them. -->
This deprecates the text-based bookmark command, now that we have the context menu command.

Any users that invoke the old text-based command will be told how to use the new context menu command in sir-lance-playground.

This also simplifies a lot of the implementation of the bookmark cog.

I suggest reviewing commit-by-commit as some code has been moved around.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
