### PR TITLE
holidayreact: add alternate spellings to February

### DIFF
--- a/bot/exts/holidays/holidayreact.py
+++ b/bot/exts/holidays/holidayreact.py
@@ -29,7 +29,7 @@ class Holiday(NamedTuple):
 
 
 Valentines = Holiday([Month.FEBRUARY], {
-    "heart": Trigger(r"\b(love(s|lie|lies)?|wuv(s|lie|lies)?|heart)\b", ["\u2764\uFE0F"]),
+    "heart": Trigger(r"\b((l|w)(ove|uv)(s|lies?)?|hearts?)\b", ["\u2764\uFE0F"]),
     }
 )
 Easter = Holiday([Month.APRIL], {

--- a/bot/exts/holidays/holidayreact.py
+++ b/bot/exts/holidays/holidayreact.py
@@ -29,7 +29,7 @@ class Holiday(NamedTuple):
 
 
 Valentines = Holiday([Month.FEBRUARY], {
-    "heart": Trigger(r"\b(love|heart)\b", ["\u2764\uFE0F"]),
+    "heart": Trigger(r"\b(love(s|lie|lies)?|wuv(s|lie|lies)?|heart)\b", ["\u2764\uFE0F"]),
     }
 )
 Easter = Holiday([Month.APRIL], {


### PR DESCRIPTION
## Relevant Issues
> Needs to match love, loves, lovelies, wuv, wuvs... quick, get Shenan in here.
> \- @Preocts, https://discord.com/channels/267624335836053506/267624335836053506/1078159856688713778

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Added alternate spellings and misspellings to the February triggers in the holidayreact cog.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
