### PR TITLE
fixed embed interaction and randomly choosing a kata

### DIFF
--- a/bot/exts/utilities/challenges.py
+++ b/bot/exts/utilities/challenges.py
@@ -84,6 +84,7 @@ class InformationDropdown(ui.Select):
         # The attribute is not set during initialization.
         result_embed = self.mapping_of_embeds[self.values[0]]
         await self.original_message.edit(embed=result_embed)
+        await interaction.response.defer()
 
 
 class Challenges(commands.Cog):
@@ -122,12 +123,8 @@ class Challenges(commands.Cog):
 
             if not first_kata_div:
                 raise commands.BadArgument("No katas could be found with the filters provided.")
-            elif len(first_kata_div) >= 3:
-                first_kata_div = choice(first_kata_div[:3])
-            elif "q=" not in search_link:
-                first_kata_div = choice(first_kata_div)
             else:
-                first_kata_div = first_kata_div[0]
+                first_kata_div = choice(first_kata_div)
 
             # There are numerous divs before arriving at the id of the kata, which can be used for the link.
             first_kata_id = first_kata_div.a["href"].split("/")[-1]


### PR DESCRIPTION
## Relevant Issues
Closes #1170 

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
The issue mentioned two problems:

1. interactions edit the message but still show as failed
The problem is that discord automatically says the interaction failed if the bot doesn't respond to the interaction. Adding interaction.response.defer() fixes this. (See this stackoverflow discussion: https://stackoverflow.com/questions/71177867/discord-py-error-message-this-interaction-failed)

2. The same challenge seems to be shown every time for a given query, where it should be random.
I believe this happened because of the if statements that chose the kata_id. Whenever a query resulted in more than 3 katas, the first elif statement was called, resulting in the same 3 katas being displayed over and over. My solution is to remove the elif statements and always make a random selection from all the katas found.


## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
