### PR TITLE
Allow .latex in python-help channel

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -57,6 +57,7 @@ class Channels(NamedTuple):
     off_topic_0 = 291284109232308226
     off_topic_1 = 463035241142026251
     off_topic_2 = 463035268514185226
+    python_help = 1035199133436354600
     sir_lancebot_playground = int(environ.get("CHANNEL_COMMUNITY_BOT_COMMANDS", 607247579608121354))
     voice_chat_0 = 412357430186344448
     voice_chat_1 = 799647045886541885

--- a/bot/exts/fun/latex.py
+++ b/bot/exts/fun/latex.py
@@ -37,6 +37,7 @@ PAD = 10
 LATEX_ALLOWED_CHANNNELS = WHITELISTED_CHANNELS + (
     Channels.data_science_and_ai,
     Channels.algos_and_data_structs,
+    Channels.python_help,
 )
 
 


### PR DESCRIPTION
## Relevant Issues
Closes #1207.

## Description
Adds the `#python-help` channel to the list of channels where `.latex` command is allowed.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
