### PR TITLE
Run null check on needed API keys before loading cogs.

### DIFF
--- a/bot/exts/events/hacktoberfest/hacktoberstats.py
+++ b/bot/exts/events/hacktoberfest/hacktoberstats.py
@@ -434,4 +434,6 @@ class HacktoberStats(commands.Cog):
 
 async def setup(bot: Bot) -> None:
     """Load the Hacktober Stats Cog."""
+    if not Tokens.github:
+        log.warning("No GitHub token was provided. The HacktoberStats Cog won't be fully functional.")
     await bot.add_cog(HacktoberStats(bot))

--- a/bot/exts/fun/movie.py
+++ b/bot/exts/fun/movie.py
@@ -208,4 +208,7 @@ class Movie(Cog):
 
 async def setup(bot: Bot) -> None:
     """Load the Movie Cog."""
+    if not Tokens.tmdb:
+        logger.warning("No TMDB token. Not loading Movie Cog.")
+        return
     await bot.add_cog(Movie(bot))

--- a/bot/exts/fun/snakes/__init__.py
+++ b/bot/exts/fun/snakes/__init__.py
@@ -9,6 +9,6 @@ log = logging.getLogger(__name__)
 
 async def setup(bot: Bot) -> None:
     """Load the Snakes Cog."""
-    if not Tokens.giphy:
-        log.warning("No Youtube token. All youtube related commands in Snakes cog won't work.")
+    if not Tokens.youtube:
+        log.warning("No Youtube token. All YouTube related commands in Snakes cog won't work.")
     await bot.add_cog(Snakes(bot))

--- a/bot/exts/fun/snakes/__init__.py
+++ b/bot/exts/fun/snakes/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from bot.bot import Bot
+from bot.constants import Tokens
 from bot.exts.fun.snakes._snakes_cog import Snakes
 
 log = logging.getLogger(__name__)
@@ -8,4 +9,6 @@ log = logging.getLogger(__name__)
 
 async def setup(bot: Bot) -> None:
     """Load the Snakes Cog."""
+    if not Tokens.giphy:
+        log.warning("No Youtube token. All youtube related commands in Snakes cog won't work.")
     await bot.add_cog(Snakes(bot))

--- a/bot/exts/holidays/halloween/scarymovie.py
+++ b/bot/exts/holidays/halloween/scarymovie.py
@@ -135,4 +135,7 @@ class ScaryMovie(commands.Cog):
 
 async def setup(bot: Bot) -> None:
     """Load the Scary Movie Cog."""
+    if not Tokens.tmdb:
+        log.warning("No TMDB Token. Not loading ScaryMovie Cog.")
+        return
     await bot.add_cog(ScaryMovie(bot))

--- a/bot/exts/holidays/halloween/spookygif.py
+++ b/bot/exts/holidays/halloween/spookygif.py
@@ -35,4 +35,7 @@ class SpookyGif(commands.Cog):
 
 async def setup(bot: Bot) -> None:
     """Spooky GIF Cog load."""
+    if not Tokens.giphy:
+        log.warning("No Giphy token. Not loading Giphy cog.")
+        return
     await bot.add_cog(SpookyGif(bot))

--- a/bot/exts/holidays/halloween/spookygif.py
+++ b/bot/exts/holidays/halloween/spookygif.py
@@ -36,6 +36,6 @@ class SpookyGif(commands.Cog):
 async def setup(bot: Bot) -> None:
     """Spooky GIF Cog load."""
     if not Tokens.giphy:
-        log.warning("No Giphy token. Not loading Giphy cog.")
+        log.warning("No Giphy token. Not loading SpookyGif cog.")
         return
     await bot.add_cog(SpookyGif(bot))

--- a/bot/exts/utilities/reddit.py
+++ b/bot/exts/utilities/reddit.py
@@ -358,6 +358,6 @@ class Reddit(Cog):
 async def setup(bot: Bot) -> None:
     """Load the Reddit cog."""
     if not RedditConfig.secret or not RedditConfig.client_id:
-        log.error("Credentials not provided, cog not loaded.")
+        log.warning("Credentials not provided, cog not loaded.")
         return
     await bot.add_cog(Reddit(bot))

--- a/bot/exts/utilities/wolfram.py
+++ b/bot/exts/utilities/wolfram.py
@@ -303,4 +303,7 @@ class Wolfram(Cog):
 
 async def setup(bot: Bot) -> None:
     """Load the Wolfram cog."""
+    if not Wolfram.key:
+        log.warning("No Wolfram API Key was provided. Not loading Wolfram Cog.")
+        return
     await bot.add_cog(Wolfram(bot))

--- a/bot/exts/utilities/wolfram.py
+++ b/bot/exts/utilities/wolfram.py
@@ -10,12 +10,12 @@ from discord.ext import commands
 from discord.ext.commands import BucketType, Cog, Context, check, group
 
 from bot.bot import Bot
-from bot.constants import Colours, STAFF_ROLES, Wolfram
+from bot.constants import Colours, STAFF_ROLES, Wolfram as WolframConfig
 from bot.utils.pagination import ImagePaginator
 
 log = logging.getLogger(__name__)
 
-APPID = Wolfram.key.get_secret_value()
+APPID = WolframConfig.key.get_secret_value()
 DEFAULT_OUTPUT_FORMAT = "JSON"
 QUERY = "http://api.wolframalpha.com/v2/{request}"
 WOLF_IMAGE = "https://www.symbols.com/gi.php?type=1&id=2886&i=1"
@@ -23,10 +23,10 @@ WOLF_IMAGE = "https://www.symbols.com/gi.php?type=1&id=2886&i=1"
 MAX_PODS = 20
 
 # Allows for 10 wolfram calls pr user pr day
-usercd = commands.CooldownMapping.from_cooldown(Wolfram.user_limit_day, 60 * 60 * 24, BucketType.user)
+usercd = commands.CooldownMapping.from_cooldown(WolframConfig.user_limit_day, 60 * 60 * 24, BucketType.user)
 
 # Allows for max api requests / days in month per day for the entire guild (Temporary)
-guildcd = commands.CooldownMapping.from_cooldown(Wolfram.guild_limit_day, 60 * 60 * 24, BucketType.guild)
+guildcd = commands.CooldownMapping.from_cooldown(WolframConfig.guild_limit_day, 60 * 60 * 24, BucketType.guild)
 
 
 async def send_embed(
@@ -303,7 +303,7 @@ class Wolfram(Cog):
 
 async def setup(bot: Bot) -> None:
     """Load the Wolfram cog."""
-    if not Wolfram.key:
+    if not WolframConfig.key:
         log.warning("No Wolfram API Key was provided. Not loading Wolfram Cog.")
         return
     await bot.add_cog(Wolfram(bot))


### PR DESCRIPTION
We have a lot of Cogs that need some API key to function.

If the key isn't present, it would result in constant 401s.

This PR adds a change that won't load these Cogs & log a warning whenever these keys aren't present.