### PR TITLE
Fix extra space in .help command signature

### DIFF
--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -286,9 +286,7 @@ class HelpSession:
             # if required
             else:
                 results.append(f"<{name}>")
-        if results:
-            return f"{cmd.qualified_name} {' '.join(results)}"
-        return cmd.qualified_name
+        return " ".join([cmd.qualified_name, *results])
 
     async def build_pages(self) -> None:
         """Builds the list of content pages to be paginated through in the help message, as a list of str."""

--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -286,8 +286,9 @@ class HelpSession:
             # if required
             else:
                 results.append(f"<{name}>")
-
-        return f"{cmd.qualified_name} {' '.join(results)}"
+        if results:
+            return f"{cmd.qualified_name} {' '.join(results)}"
+        return cmd.qualified_name
 
     async def build_pages(self) -> None:
         """Builds the list of content pages to be paginated through in the help message, as a list of str."""


### PR DESCRIPTION
## Relevant Issues

Closes #1266 


## Description
Fix extra space being added to command signature in `.help` command

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
