### PR TITLE
Use title as parameter name for Embed in monster_vote

### DIFF
--- a/bot/exts/holidays/halloween/monstersurvey.py
+++ b/bot/exts/holidays/halloween/monstersurvey.py
@@ -109,7 +109,7 @@ class MonsterSurvey(Cog):
                 name = name.lower()
 
             vote_embed = Embed(
-                name="Monster Voting",
+                title="Monster Voting",
                 color=0xFF6800
             )
 


### PR DESCRIPTION
## Relevant Issues

Closes #1347 

## Description
Change parameter name from `name` to `title` in a call to `Embed` in monstersurvey.py.

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
