### PR TITLE
Replace or with space in christmas tree holiday reaction

### DIFF
--- a/bot/exts/holidays/holidayreact.py
+++ b/bot/exts/holidays/holidayreact.py
@@ -61,7 +61,7 @@ Hanukkah = Holiday([Month.NOVEMBER, Month.DECEMBER], {
     }
 )
 Christmas = Holiday([Month.DECEMBER], {
-    "christmas tree": Trigger(r"\b((christ|x)mas|tree)\b", ["\U0001F384"]),
+    "christmas tree": Trigger(r"\b((christ|x)mas tree)\b", ["\U0001F384"]),
     "reindeer": Trigger(r"\b(reindeer|caribou|buck|stag)\b", ["\U0001F98C"]),
     "santa": Trigger(r"\bsanta\b", ["\U0001F385"]),
     "snowflake": Trigger(r"\b(snow ?)?flake(?! ?8)\b", ["\u2744\uFE0F"]),


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->
This is one possible solution to #1403. I'll leave the floor open for discussion over other options.

## Description
<!-- Describe what changes you made, and how you've implemented them. -->

`christmas|tree` -> `christmas tree` to make sure that we only react to trees of the Christmas variety.

<details>

<summary>regex101 screenshots</summary>

![image](https://github.com/python-discord/sir-lancebot/assets/54628770/8bf7a418-ba92-4e1c-bb2f-3e06cce3151e)
![image](https://github.com/python-discord/sir-lancebot/assets/54628770/799661b9-bfec-4a45-a4fa-276d1686fbcb)

</details>

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
