### PR TITLE
Remove "What third-party library do you wish was in the Python standard library?" from topics

### DIFF
--- a/bot/resources/utilities/py_topics.yaml
+++ b/bot/resources/utilities/py_topics.yaml
@@ -39,7 +39,6 @@
     - What's your favorite Python related book?
     - What's your favorite use of recursion in Python?
     - If you could change one thing in Python, what would it be?
-    - What third-party library do you wish was in the Python standard library?
     - Which package do you use the most and why?
     - Which Python feature do you love the most?
     - Do you have any plans for future projects?


### PR DESCRIPTION
## Relevant Issues

Raised by @nedbat on [Discord](https://discord.com/channels/267624335836053506/385474242440986624/1192436157691220021) (requires PyDis Helpers role)


## Description
<!-- Describe what changes you made, and how you've implemented them. -->

- Removed "What third-party library do you wish was in the Python standard library?" from topics

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
