### PR TITLE
Correctly type revisions as an int

### DIFF
--- a/bot/exts/utilities/rfc.py
+++ b/bot/exts/utilities/rfc.py
@@ -20,7 +20,7 @@ class RfcDocument(pydantic.BaseModel):
 
     title: str
     description: str
-    revisions: str
+    revisions: int
     created: datetime.datetime
 
 


### PR DESCRIPTION
Solves #1426 Soves SIR-LANCEBOT-BA

This was causing a pydantic validation error, was it was being passed a string.

The only place this is used internaly casts it to a string anyway, so no further changes were needed.

## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
-->

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [ ] Join the [**Python Discord Community**](https://discord.gg/python)?
- [ ] Read all the comments in this template?
- [ ] Ensure there is an issue open, or link relevant discord discussions?
- [ ] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
