### PR TITLE
Support issues closed as not-planned in GitHub Issue linking

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -166,7 +166,8 @@ class Emojis:
 
     # These icons are from Github's repo https://github.com/primer/octicons/
     issue_open = "<:IssueOpen:852596024777506817>"
-    issue_closed = "<:IssueClosed:927326162861039626>"
+    issue_completed = "<:IssueClosed:927326162861039626>"
+    issue_not_planned = "<:IssueNotPlanned:1221642127595929610>"
     issue_draft = "<:IssueDraft:852596025147523102>"  # Not currently used by Github, but here for future.
     pull_request_open = "<:PROpen:852596471505223781>"
     pull_request_closed = "<:PRClosed:852596024732286976>"

--- a/bot/exts/utilities/githubinfo.py
+++ b/bot/exts/utilities/githubinfo.py
@@ -114,10 +114,11 @@ class GithubInfo(commands.Cog):
         # from issues: if the 'issues' key is present in the response then we can pull the data we
         # need from the initial API call.
         if "issues" in json_data["html_url"]:
-            if json_data.get("state") == "open":
-                emoji = Emojis.issue_open
-            else:
-                emoji = Emojis.issue_closed
+            emoji = Emojis.issue_open
+            if json_data.get("state") == "closed":
+                emoji = Emojis.issue_completed
+            if json_data.get("state_reason") == "not_planned":
+                emoji = Emojis.issue_not_planned
 
         # If the 'issues' key is not contained in the API response and there is no error code, then
         # we know that a PR has been requested and a call to the pulls API endpoint is necessary


### PR DESCRIPTION
Closes #999.

Issues which are closed with reason "not-planned" will show up next to the correct icon as used by github. This emoji [has been added](https://discord.com/channels/267624335836053506/635950537262759947/1221642237004484739) to the emoji server.

Any other reasons for closing will use the completion icon.

