### PR TITLE
Replace sentry experiment with standard version and add AsyncioIntegration

### DIFF
--- a/bot/log.py
+++ b/bot/log.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import coloredlogs
 import sentry_sdk
 from pydis_core.utils import logging as core_logging
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -62,13 +63,12 @@ def setup_sentry() -> None:
         dsn=Client.sentry_dsn,
         integrations=[
             sentry_logging,
+            AsyncioIntegration(),
             RedisIntegration(),
         ],
         release=f"bot@{GIT_SHA}",
         traces_sample_rate=0.5,
-        _experiments={
-            "profiles_sample_rate": 0.5,
-        },
+        profiles_sample_rate=0.5,
     )
 
 


### PR DESCRIPTION
There aren't any transactions currently, so this wont do much, but the experiment config will be removed in the future so we shouldn't use it, and this brings us more in line with bot's config.