### PR TITLE
Improve formatting of ping and uptime commands

### DIFF
--- a/bot/exts/core/ping.py
+++ b/bot/exts/core/ping.py
@@ -2,6 +2,7 @@ import arrow
 from dateutil.relativedelta import relativedelta
 from discord import Embed
 from discord.ext import commands
+from discord.utils import format_dt
 
 from bot import start_time
 from bot.bot import Bot
@@ -29,16 +30,7 @@ class Ping(commands.Cog):
     @commands.command(name="uptime")
     async def uptime(self, ctx: commands.Context) -> None:
         """Get the current uptime of the bot."""
-        difference = relativedelta(start_time - arrow.utcnow())
-        uptime_string = start_time.shift(
-            seconds=-difference.seconds,
-            minutes=-difference.minutes,
-            hours=-difference.hours,
-            days=-difference.days
-        ).humanize()
-
-        await ctx.send(f"I started up {uptime_string}.")
-
+        await ctx.reply(f"I started up {format_dt(start_time.datetime, 'R')}.")
 
 async def setup(bot: Bot) -> None:
     """Load the Ping cog."""

--- a/bot/exts/core/ping.py
+++ b/bot/exts/core/ping.py
@@ -21,7 +21,7 @@ class Ping(commands.Cog):
         embed = Embed(
             title=":ping_pong: Pong!",
             colour=Colours.bright_green,
-            description=f"Gateway Latency: {round(self.bot.latency * 1000)}ms",
+            description=f"Gateway Latency: `{round(self.bot.latency * 1000)}`ms",
         )
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
## Description
I changed the `uptime` command to use a discord formatted timestamp, rather than formatting the start_time and sending it. This way you can see exactly when the bot started, in your own timezone.

In addition, I also added some small formatting to the ping command, so the gateway ping is show in a tiny codeblock `like this`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
