### PR TITLE
Migration to official Sentry release CI action

### DIFF
--- a/.github/workflows/sentry_release.yaml
+++ b/.github/workflows/sentry_release.yaml
@@ -10,12 +10,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create a Sentry.io release
-        uses: tclindner/sentry-releases-action@v1.3.0
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: sir-lancebot
         with:
-          tagName: ${{ github.sha }}
           environment: production
-          releaseNamePrefix: sir-lancebot@
+          version_prefix: sir-lancebot@


### PR DESCRIPTION
https://github.com/tclindner/sentry-releases-action no longer works, this PR migrates to the [official sentry release CI action](https://github.com/getsentry/action-release).