### PR TITLE
Typst command implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 log/*
 data/*
 bot/exts/fun/_latex_cache/*
+bot/exts/fun/_typst_cache/*
 
 
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -86,4 +86,6 @@ async def main() -> None:
                 await _bot.start(constants.Client.token.get_secret_value())
 
 
-asyncio.run(main())
+# the main-guard is needed for launching subprocesses, e.g. via anyio.to_process
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -305,6 +305,23 @@ class _Reddit(EnvConfig, env_prefix="reddit_"):
 
 Reddit = _Reddit()
 
+
+# "typst_" is the prefix for Typst's own envvars, so "typstext_"
+class _Typst(EnvConfig, env_prefix="typstext_"):
+    # the path to the typst binary that will be used.
+    # the Typst cog can download it to this path automatically
+    typst_path: str = "bot/exts/fun/_typst_cache/typst"
+
+    # fetching configuration. note that the defaults assume Linux on x86_64
+
+    # the direct url to fetch a typst release archive from. It will be unpacked and the executable from it used.
+    typst_archive_url: str = "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz"
+    # SHA256 hex digest the archive at typst_archive_url will be checked against. can be obtained by sha256sum
+    typst_archive_sha256: str = "605130a770ebd59a4a579673079cb913a13e75985231657a71d6239a57539ec3"
+
+
+Typst = _Typst()
+
 # Default role combinations
 MODERATION_ROLES = {Roles.moderation_team, Roles.admins, Roles.owners}
 STAFF_ROLES = {Roles.helpers, Roles.moderation_team, Roles.admins, Roles.owners}

--- a/bot/exts/fun/latex.py
+++ b/bot/exts/fun/latex.py
@@ -36,11 +36,6 @@ LATEX_ALLOWED_CHANNNELS = WHITELISTED_CHANNELS + (
 )
 
 
-def _process_image(data: bytes, out_file: BinaryIO) -> None:
-    """Read `data` as an image file, and paste it on a white background."""
-    return process_image(data, out_file, PAD)
-
-
 class InvalidLatexError(Exception):
     """Represents an error caused by invalid latex."""
 
@@ -73,7 +68,7 @@ class Latex(commands.Cog):
             f"{LATEX_API_URL}/{response_json['filename']}",
             raise_for_status=True
         ) as response:
-            _process_image(await response.read(), out_file)
+            process_image(await response.read(), out_file, PAD)
 
     async def _upload_to_pastebin(self, text: str) -> str | None:
         """Uploads `text` to the paste service, returning the url if successful."""

--- a/bot/exts/fun/typst.py
+++ b/bot/exts/fun/typst.py
@@ -1,0 +1,127 @@
+import asyncio
+import hashlib
+import string
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import discord
+from discord.ext import commands
+from pydis_core.utils.logging import get_logger
+from pydis_core.utils.paste_service import PasteFile, PasteTooLongError, PasteUploadError, send_to_paste_service
+
+from bot.bot import Bot
+from bot.constants import Channels, WHITELISTED_CHANNELS
+from bot.utils.codeblocks import prepare_input
+from bot.utils.decorators import whitelist_override
+from bot.utils.typst import render_typst_worker
+
+log = get_logger(__name__)
+
+PASTEBIN_URL = "https://paste.pythondiscord.com"
+
+THIS_DIR = Path(__file__).parent
+# The cache directory used for typst. A temporary subdirectory is made for each invocation,
+# which should be cleaned up automatically on success.
+CACHE_DIRECTORY = THIS_DIR / "_typst_cache"
+CACHE_DIRECTORY.mkdir(exist_ok=True)
+TEMPLATE = string.Template(Path("bot/resources/fun/typst_template.typ").read_text())
+
+MAX_CONCURRENCY = 2
+
+TYPST_ALLOWED_CHANNNELS = WHITELISTED_CHANNELS + (
+    Channels.data_science_and_ai,
+    Channels.algos_and_data_structs,
+    Channels.python_help,
+)
+
+_EXECUTOR = ProcessPoolExecutor(MAX_CONCURRENCY)
+
+
+class InvalidTypstError(Exception):
+    """Represents an error caused by invalid typst source code."""
+
+    def __init__(self, logs: str | None):
+        super().__init__(logs)
+        self.logs = logs
+
+
+class Typst(commands.Cog):
+    """Renders typst."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @commands.command()
+    @commands.max_concurrency(MAX_CONCURRENCY, commands.BucketType.guild, wait=True)
+    @whitelist_override(channels=TYPST_ALLOWED_CHANNNELS)
+    async def typst(self, ctx: commands.Context, *, query: str) -> None:
+        """Renders the text in typst and sends the image."""
+        query = prepare_input(query)
+
+        # the hash of the query is used as the tempdir name in the cache,
+        # as well as the name for the rendered file.
+        query_hash = hashlib.md5(query.encode()).hexdigest()  # noqa: S324
+        image_path = CACHE_DIRECTORY / f"{query_hash}.png"
+        async with ctx.typing():
+            if not image_path.exists():
+                try:
+                    await self.render_typst(query, query_hash, image_path)
+                except InvalidTypstError as err:
+                    embed = await self._prepare_error_embed(err)
+                    await ctx.send(embed=embed)
+                    image_path.unlink()
+                    return
+            await ctx.send(file=discord.File(image_path, "typst.png"))
+
+    async def render_typst(self, query: str, tempdir_name: str, image_path: Path) -> None:
+        """
+        Renders the query as Typst.
+
+        Does so by writing it into a file in a temporary directory, storing the output in image_path.
+        image_path shouldn't be in that directory or else it will be immediately deleted.
+        """
+        with TemporaryDirectory(prefix=tempdir_name, dir=CACHE_DIRECTORY) as tempdir:
+            source_path = Path(tempdir) / "inp.typ"
+            source_path.write_text(TEMPLATE.substitute(text=query), encoding="utf-8")
+            try:
+                await asyncio.get_event_loop().run_in_executor(
+                    _EXECUTOR, render_typst_worker, source_path, image_path
+                )
+            except RuntimeError as e:
+                raise InvalidTypstError(e.args[0] if e.args else "<no error message emitted>")
+
+    async def _prepare_error_embed(
+        self, err: InvalidTypstError | None
+    ) -> discord.Embed:
+        title = "There was some issue rendering your Typst, please retry later."
+        if isinstance(err, InvalidTypstError):
+            title = "Failed to render input as Typst."
+
+        embed = discord.Embed(title=title)
+        embed.description = "No logs available."
+        logs = getattr(err, "logs", None)
+        if logs:
+            logs_paste_url = await self._upload_to_pastebin(logs)
+            embed.description = "Couldn't upload logs."
+            if logs_paste_url:
+                embed.description = f"[View Logs]({logs_paste_url})"
+        return embed
+
+    async def _upload_to_pastebin(self, text: str) -> str | None:
+        """Uploads `text` to the paste service, returning the url if successful."""
+        file = PasteFile(content=text, lexer="text")
+        try:
+            resp = await send_to_paste_service(
+                files=[file],
+                http_session=self.bot.http_session,
+            )
+            return resp.link
+        except (PasteTooLongError, PasteUploadError) as e:
+            log.info("Error when uploading typst output to pastebin. %s", e)
+            return None
+
+
+async def setup(bot: Bot) -> None:
+    """Load the Typst Cog."""
+    await bot.add_cog(Typst(bot))

--- a/bot/exts/fun/typst.py
+++ b/bot/exts/fun/typst.py
@@ -120,10 +120,18 @@ class Typst(commands.Cog):
     async def _download_typst_executable(self) -> None:
         if not Config.typst_archive_url:
             raise ValueError("Trying to download Typst but the archive URL isn't set")
+        if not Config.typst_archive_sha256:
+            raise ValueError("Trying to download Typst but the archive hash isn't set")
         async with self.bot.http_session.get(
             Config.typst_archive_url, raise_for_status=True
         ) as response:
             arc_data = await response.read()
+        digest = hashlib.sha256(arc_data).hexdigest()
+        if digest != Config.typst_archive_sha256:
+            raise ValueError(
+                f"Retrieved archive doesn't match hash {Config.typst_archive_sha256}; "
+                f"instead got file with size {len(arc_data)} and hash {digest}"
+            )
         log.info("Retrieved Typst archive, unpacking")
         typst_executable = archive_retrieve_file(
             arc_data,

--- a/bot/resources/fun/typst_packages.typ
+++ b/bot/resources/fun/typst_packages.typ
@@ -1,0 +1,6 @@
+// This file is ran to install the allowed packages before the package directory is write-locked.
+// It is NOT included into every query's template.
+#import "@preview/codly:1.0.0" // code presentation (needs configuration in the document to work)
+#import "@preview/cetz:0.3.0" // similar to latex's tikz
+#import "@preview/fletcher:0.5.1" as fletcher // drawing diagrams; depends on cetz
+#import "@preview/physica:0.9.3" // math and physics

--- a/bot/resources/fun/typst_packages.typ
+++ b/bot/resources/fun/typst_packages.typ
@@ -1,6 +1,6 @@
 // This file is ran to install the allowed packages before the package directory is write-locked.
 // It is NOT included into every query's template.
 #import "@preview/codly:1.0.0" // code presentation (needs configuration in the document to work)
-#import "@preview/cetz:0.3.0" // similar to latex's tikz
-#import "@preview/fletcher:0.5.1" as fletcher // drawing diagrams; depends on cetz
+#import "@preview/cetz:0.3.1" // similar to latex's tikz
+#import "@preview/fletcher:0.5.2" // drawing diagrams; depends on cetz
 #import "@preview/physica:0.9.3" // math and physics

--- a/bot/resources/fun/typst_template.typ
+++ b/bot/resources/fun/typst_template.typ
@@ -1,0 +1,5 @@
+// stretch instead of producing an entire page
+// margin:0cm cuts off parts of letters, so add a bit more.
+#set page("a4", width: auto, height: auto, margin: 0.25cm)
+
+$text

--- a/bot/resources/fun/typst_template.typ
+++ b/bot/resources/fun/typst_template.typ
@@ -1,5 +1,4 @@
-// stretch instead of producing an entire page
 // margin:0cm cuts off parts of letters, so add a bit more.
-#set page("a4", width: auto, height: auto, margin: 0.25cm)
+#set page("a4", height: auto, margin: 0.5cm)
 
 $text

--- a/bot/utils/archives.py
+++ b/bot/utils/archives.py
@@ -1,0 +1,44 @@
+import tarfile
+import typing
+import zipfile
+from io import BytesIO
+from pathlib import PurePath
+
+
+def _tar_retrieve_file(archive_data: typing.BinaryIO, filename: str) -> bytes:
+    with tarfile.open(fileobj=archive_data) as arc:
+        for el in arc.getmembers():
+            if PurePath(el.name).name == filename:
+                fo = arc.extractfile(el)
+                if fo is None:
+                    raise ValueError(
+                        "Member has the right name but couldn't extract:", el
+                    )
+                return fo.read()
+    raise FileNotFoundError("No member with this name was found in archive:", filename)
+
+
+def _zip_retrieve_file(archive_data: typing.BinaryIO, filename: str) -> bytes:
+    with zipfile.ZipFile(file=archive_data) as arc:
+        for el in arc.filelist:
+            if PurePath(el.filename).name == filename:
+                return arc.read(el)
+    raise FileNotFoundError("No member with this name was found in archive:", filename)
+
+
+def archive_retrieve_file(
+    archive_data: bytes | typing.BinaryIO, filename: str
+) -> bytes:
+    """Retrieves a single file by filename (not by full path) from a tar or zip archive in memory."""
+    if isinstance(archive_data, bytes | bytearray | memoryview):
+        archive_data = BytesIO(archive_data)
+    if tarfile.is_tarfile(archive_data):
+        return _tar_retrieve_file(archive_data, filename)
+    try:
+        return _zip_retrieve_file(archive_data, filename)
+    except zipfile.BadZipFile as e:
+        if "File is not a zip file" in str(e):
+            raise ValueError(
+                "Archive unsupported: was neither a valid tarfile nor a valid zipfile"
+            )
+        raise

--- a/bot/utils/archives.py
+++ b/bot/utils/archives.py
@@ -15,7 +15,7 @@ def _tar_retrieve_file(archive_data: typing.BinaryIO, filename: str) -> bytes:
                         "Member has the right name but couldn't extract:", el
                     )
                 return fo.read()
-    raise FileNotFoundError("No member with this name was found in archive:", filename)
+    raise ValueError("No member with this name was found in archive:", filename)
 
 
 def _zip_retrieve_file(archive_data: typing.BinaryIO, filename: str) -> bytes:
@@ -23,7 +23,7 @@ def _zip_retrieve_file(archive_data: typing.BinaryIO, filename: str) -> bytes:
         for el in arc.filelist:
             if PurePath(el.filename).name == filename:
                 return arc.read(el)
-    raise FileNotFoundError("No member with this name was found in archive:", filename)
+    raise ValueError("No member with this name was found in archive:", filename)
 
 
 def archive_retrieve_file(

--- a/bot/utils/codeblocks.py
+++ b/bot/utils/codeblocks.py
@@ -1,0 +1,18 @@
+import re
+
+FORMATTED_CODE_REGEX = re.compile(
+    r"(?P<delim>(?P<block>```)|``?)"        # code delimiter: 1-3 backticks; (?P=block) only matches if it's a block
+    r"(?(block)(?:(?P<lang>[a-z]+)\n)?)"    # if we're in a block, match optional language (only letters plus newline)
+    r"(?:[ \t]*\n)*"                        # any blank (empty or tabs/spaces only) lines before the code
+    r"(?P<code>.*?)"                        # extract all code inside the markup
+    r"\s*"                                  # any more whitespace before the end of the code markup
+    r"(?P=delim)",                          # match the exact same delimiter from the start again
+    re.DOTALL | re.IGNORECASE,              # "." also matches newlines, case insensitive
+)
+
+
+def prepare_input(text: str) -> str:
+    """Extract input from a codeblock, if it is in one. Otherwise returns the entire text."""
+    if match := FORMATTED_CODE_REGEX.match(text):
+        return match.group("code")
+    return text

--- a/bot/utils/images.py
+++ b/bot/utils/images.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from typing import BinaryIO
 
-from PIL import Image
+from PIL import Image, ImageChops
 
 
 def process_image(data: bytes, out_file: BinaryIO, pad: int) -> None:
@@ -15,3 +15,35 @@ def process_image(data: bytes, out_file: BinaryIO, pad: int) -> None:
     # this has the effect of skipping pasting the pixels where the image is transparent.
     background.paste(image, (pad, pad), image)
     background.save(out_file)
+
+
+def crop_background(
+    img: Image.Image, background_color: tuple[int, ...], pad: int = 0
+) -> Image.Image | None:
+    """
+    Crops the image to include only the pixels that aren't the `background_color`. Optionally leaves some padding.
+
+    If the image is totally empty, returns None if pad==0, otherwise an empty image of only the padding.
+    """
+    if not pad >= 0:
+        raise ValueError(f"pad must be >=0, got {pad}")
+
+    # https://stackoverflow.com/a/48605963
+    bg = Image.new(img.mode, img.size, background_color)
+    diff = ImageChops.difference(img, bg)
+    diff = ImageChops.add(diff, diff, 2.0, -100)
+    bbox = diff.getbbox()
+    if not bbox:
+        if pad == 0:
+            return None
+        # empty image with padding-related sizes
+        bbox = (0, 0, 2 * pad, 2 * pad)
+    else:
+        l, u, r, b = bbox  # noqa: E741
+        bbox = (
+            max(l - pad, 0),
+            max(u - pad, 0),
+            min(r + pad, img.width),
+            min(b + pad, img.height),
+        )
+    return img.crop(bbox)

--- a/bot/utils/images.py
+++ b/bot/utils/images.py
@@ -1,0 +1,17 @@
+from io import BytesIO
+from typing import BinaryIO
+
+from PIL import Image
+
+
+def process_image(data: bytes, out_file: BinaryIO, pad: int) -> None:
+    """Read `data` as an image file, and paste it on a white background."""
+    image = Image.open(BytesIO(data)).convert("RGBA")
+    width, height = image.size
+    background = Image.new("RGBA", (width + 2 * pad, height + 2 * pad), "WHITE")
+
+    # paste the image on the background, using the same image as the mask
+    # when an RGBA image is passed as the mask, its alpha band is used.
+    # this has the effect of skipping pasting the pixels where the image is transparent.
+    background.paste(image, (pad, pad), image)
+    background.save(out_file)

--- a/bot/utils/typst.py
+++ b/bot/utils/typst.py
@@ -1,65 +1,78 @@
+import asyncio.subprocess
+import contextlib
 import resource
-import warnings
-from collections.abc import Iterator
-from contextlib import contextmanager, nullcontext
-from multiprocessing import parent_process
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Literal
 
-
-@contextmanager
-def rlimit_context(
-    resource_id: int, soft_value: int | None = None, hard_value: int | None = None
-) -> Iterator[None]:
-    """
-    Context manager to temporarily set an rlimit to a value and restore it on exit.
-
-    A value of None for one of the limits means that the current value will be used.
-    This should typically be used in a subprocess, and will emit a warning if used from the main process.
-    """
-    if soft_value is None and hard_value is None:
-        warnings.warn(
-            "rlimit_context does nothing if both soft_value and hard_value are None",
-            stacklevel=2,
-        )
-    if parent_process() is None:
-        warnings.warn("rlimit_context used from main process", stacklevel=2)
-
-    old_soft, old_hard = resource.getrlimit(resource_id)
-    new_soft, new_hard = old_soft, old_hard
-    if soft_value is not None:
-        new_soft = soft_value
-    if hard_value is not None:
-        new_hard = hard_value
-
-    resource.setrlimit(resource_id, (new_soft, new_hard))
-    try:
-        yield
-    finally:
-        resource.setrlimit(resource_id, (old_soft, old_hard))
+from bot.constants import Typst as Config
 
 
-def render_typst_worker(
-    source_path: Path,
+def _set_limits(mem_rlimit: int | None = None) -> None:
+    if mem_rlimit is not None:
+        resource.setrlimit(resource.RLIMIT_AS, (mem_rlimit, -1))
+
+
+@dataclass
+class TypstCompileResult:
+    """Result of Typst compilation."""
+
+    output: bytes
+    stderr: bytes
+
+
+async def compile_typst(
+    source: str,
+    root_path: Path,
     format: Literal["pdf", "svg", "png"] = "png",
     ppi: float | None = None,
     mem_rlimit: int | None = None,
-) -> bytes:
+    jobs: int | None = None,
+) -> TypstCompileResult:
     """
-    Renders Typst from source to output.
+    Renders Typst in a subprocess.
 
-    Uses the source path's parent as the typst root path.
-    Intended to be ran in a subprocess for concurrency and timeouts.
+    Since malicious Typst source can take arbitrary resources to compile,
+    this should be ran with a timeout, and ideally a `mem_rlimit`.
+    `root_path` should be a path to a directory where all the files (if any)
+    that should be accessible are placed.
+
     """
-    import typst
+    typst_path = Path(Config.typst_path).resolve()
+    if not typst_path.exists():
+        raise FileNotFoundError("Typst executable was not found at path", typst_path)
+    if not root_path.is_dir():
+        raise ValueError("Root directory was not a directory", root_path)
 
-    ctx = (
-        rlimit_context(resource.RLIMIT_AS, soft_value=mem_rlimit)
-        if mem_rlimit is not None
-        else nullcontext()
-    )
-    with ctx:
-        res = typst.compile(
-            source_path, format=format, root=source_path.parent, ppi=ppi
+    args = [
+        "compile",
+        "--root",
+        root_path,
+        "--format",
+        format,
+    ]
+    if ppi is not None:
+        args += ["--ppi", str(ppi)]
+    if jobs is not None:
+        args += ["--jobs", str(jobs)]
+    # input and output from CLI
+    args += ["-", "-"]
+
+    try:
+        proc = await asyncio.subprocess.create_subprocess_exec(
+            typst_path,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            preexec_fn=partial(_set_limits, mem_rlimit=mem_rlimit),
         )
-    return res
+
+        stdout, stderr = await proc.communicate(input=source.encode("utf-8"))
+    # if the task is cancelled or any other problem happens, make sure to kill the worker
+    except BaseException:
+        with contextlib.suppress(UnboundLocalError):
+            proc.kill()
+        raise
+    return TypstCompileResult(output=stdout, stderr=stderr)

--- a/bot/utils/typst.py
+++ b/bot/utils/typst.py
@@ -1,7 +1,50 @@
+import resource
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
+from multiprocessing import parent_process
 from pathlib import Path
+from typing import Literal
 
 
-def render_typst_worker(source_path: Path, output_path: Path, ppi: float | None = None) -> None:
+@contextmanager
+def rlimit_context(
+    resource_id: int, soft_value: int | None = None, hard_value: int | None = None
+) -> Iterator[None]:
+    """
+    Context manager to temporarily set an rlimit to a value and restore it on exit.
+
+    A value of None for one of the limits means that the current value will be used.
+    This should typically be used in a subprocess, and will emit a warning if used from the main process.
+    """
+    if soft_value is None and hard_value is None:
+        warnings.warn(
+            "rlimit_context does nothing if both soft_value and hard_value are None",
+            stacklevel=2,
+        )
+    if parent_process() is None:
+        warnings.warn("rlimit_context used from main process", stacklevel=2)
+
+    old_soft, old_hard = resource.getrlimit(resource_id)
+    new_soft, new_hard = old_soft, old_hard
+    if soft_value is not None:
+        new_soft = soft_value
+    if hard_value is not None:
+        new_hard = hard_value
+
+    resource.setrlimit(resource_id, (new_soft, new_hard))
+    try:
+        yield
+    finally:
+        resource.setrlimit(resource_id, (old_soft, old_hard))
+
+
+def render_typst_worker(
+    source_path: Path,
+    format: Literal["pdf", "svg", "png"] = "png",
+    ppi: float | None = None,
+    mem_rlimit: int | None = None,
+) -> bytes:
     """
     Renders Typst from source to output.
 
@@ -10,4 +53,13 @@ def render_typst_worker(source_path: Path, output_path: Path, ppi: float | None 
     """
     import typst
 
-    typst.compile(source_path, output_path, root=source_path.parent, ppi=ppi)
+    ctx = (
+        rlimit_context(resource.RLIMIT_AS, soft_value=mem_rlimit)
+        if mem_rlimit is not None
+        else nullcontext()
+    )
+    with ctx:
+        res = typst.compile(
+            source_path, format=format, root=source_path.parent, ppi=ppi
+        )
+    return res

--- a/bot/utils/typst.py
+++ b/bot/utils/typst.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def render_typst_worker(source_path: Path, output_path: Path, ppi: float | None = None) -> None:
+    """
+    Renders Typst from source to output.
+
+    Uses the source path's parent as the typst root path.
+    Intended to be ran in a subprocess for concurrency and timeouts.
+    """
+    import typst
+
+    typst.compile(source_path, output_path, root=source_path.parent, ppi=ppi)

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,6 +147,26 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.6.2.post1"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
+    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+
+[package.extras]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "arrow"
 version = "1.3.0"
 description = "Better dates & times for Python"
@@ -1707,6 +1727,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1963,4 +1994,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "6795e79a85089141b6ae1c03b276e20a83fed0bdc15a14a624f75bbedb8b6ea8"
+content-hash = "10be1c2e7a594408a281c4037f21f0af66b1815118ef75dacb33bfd72ffcf03a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -147,26 +147,6 @@ files = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.6.2.post1"
-description = "High level compatibility layer for multiple asynchronous event loop implementations"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
-    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
-]
-
-[package.dependencies]
-idna = ">=2.8"
-sniffio = ">=1.1"
-
-[package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
-trio = ["trio (>=0.26.1)"]
-
-[[package]]
 name = "arrow"
 version = "1.3.0"
 description = "Better dates & times for Python"
@@ -1727,17 +1707,6 @@ files = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-description = "Sniff out which async library your code is running under"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
-    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
-]
-
-[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1818,26 +1787,6 @@ python-versions = ">=3.8"
 files = [
     {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
     {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
-]
-
-[[package]]
-name = "typst"
-version = "0.12.0"
-description = "Python binding to typst"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "typst-0.12.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a464184f6d8c327fbb28c51ab9dd1d5ee1b49ffa3b252977df7f8b2346bd3d3f"},
-    {file = "typst-0.12.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9b28aaae36637661421216cec81b7f7c55eafc80343266dd7fa67201f7c4c7e"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8537f151d339304576173a4ce48d7f8e1806729a32c09393b3800b89653b88f4"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:714c716300d073eb51f87e5c6ef743e4319d08fb693d5ad53f17d1cdbdaa986c"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb2c2899fd85ab5e2a708811e94a2411bc3143152b328482f0b23d96006e18c1"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:571b01f8fb4c161288143628528596ce6573e7dce867241f1451e4c250862576"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0442734f24b5abeb66db4690016a65a933617141ed26f43af95281b0b0e27a7"},
-    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28e53c2a123c3ea825a95ab7101202ae548a61cb773c80b0db5793570893f26a"},
-    {file = "typst-0.12.0-cp37-abi3-win32.whl", hash = "sha256:69a8ef18fbcb6bb10376d111597e464a1d80b63586a5a5324f6b4a3e1bb6f6a5"},
-    {file = "typst-0.12.0-cp37-abi3-win_amd64.whl", hash = "sha256:f8d12ba034ce3d2579bc4284a99e6bab5dd83440cd643a25546997b6b58041f8"},
-    {file = "typst-0.12.0.tar.gz", hash = "sha256:e3575e0a0a6e323b6e9fb367e838a4caa947112e38ee32911cdaaa9c85176ac5"},
 ]
 
 [[package]]
@@ -1994,4 +1943,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "212ca55d9f279d0c28568ed456d56c80cd758273cae56006b1c473b06f38d61d"
+content-hash = "56ecbd30a95a09c65cef191fda4846952082ca086eca97a46cb2547e8ec4a7de"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1822,22 +1822,22 @@ files = [
 
 [[package]]
 name = "typst"
-version = "0.11.1"
+version = "0.12.0"
 description = "Python binding to typst"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typst-0.11.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ec50fc97f8afe6da1f8787a72f77f04ddf14e007c88a1b130cb8122a405e4e63"},
-    {file = "typst-0.11.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8af0dabc95a761b07f19c4551da9176bc1b408a9abf9d5d0ab93da3d616abf6"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d6bf84d7e1c8402241d10874a4dc4df4995dcff0a581c47b1def92cc4de322b"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11c925fab98fdce6b3f8c498c399eed7224d7a315348aa46e2bb0d9a40af5baa"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:812b99f617aabb599508e132cdc881a751d89ad32504def774d3e3b765425872"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:75313042a605c15649f23eb074c5df34bca66f5b921cd043651afd80ff3ad9f0"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ffba53328e317b9b0a4e9d05573c98c7f7d4e555259e1ff5a9a2169a85232d71"},
-    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef8e44bec7a2e168a92aec2fa8008328b630d137753c0550ba654c7855d2893a"},
-    {file = "typst-0.11.1-cp37-abi3-win32.whl", hash = "sha256:e2ccebab8f9fc49b2b212d6af0e349aa6cd8fc043c343bf5719aa1ef7dae354f"},
-    {file = "typst-0.11.1-cp37-abi3-win_amd64.whl", hash = "sha256:3874f7910687406ee7e80de1aec58487c305b76893b50a3a869496105a5767a5"},
-    {file = "typst-0.11.1.tar.gz", hash = "sha256:56a336fef1dbec6ae678d87d680a90ad07c8739bc0599b54fdd7fa351a4efa56"},
+    {file = "typst-0.12.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a464184f6d8c327fbb28c51ab9dd1d5ee1b49ffa3b252977df7f8b2346bd3d3f"},
+    {file = "typst-0.12.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9b28aaae36637661421216cec81b7f7c55eafc80343266dd7fa67201f7c4c7e"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8537f151d339304576173a4ce48d7f8e1806729a32c09393b3800b89653b88f4"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:714c716300d073eb51f87e5c6ef743e4319d08fb693d5ad53f17d1cdbdaa986c"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb2c2899fd85ab5e2a708811e94a2411bc3143152b328482f0b23d96006e18c1"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:571b01f8fb4c161288143628528596ce6573e7dce867241f1451e4c250862576"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0442734f24b5abeb66db4690016a65a933617141ed26f43af95281b0b0e27a7"},
+    {file = "typst-0.12.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28e53c2a123c3ea825a95ab7101202ae548a61cb773c80b0db5793570893f26a"},
+    {file = "typst-0.12.0-cp37-abi3-win32.whl", hash = "sha256:69a8ef18fbcb6bb10376d111597e464a1d80b63586a5a5324f6b4a3e1bb6f6a5"},
+    {file = "typst-0.12.0-cp37-abi3-win_amd64.whl", hash = "sha256:f8d12ba034ce3d2579bc4284a99e6bab5dd83440cd643a25546997b6b58041f8"},
+    {file = "typst-0.12.0.tar.gz", hash = "sha256:e3575e0a0a6e323b6e9fb367e838a4caa947112e38ee32911cdaaa9c85176ac5"},
 ]
 
 [[package]]
@@ -1994,4 +1994,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "10be1c2e7a594408a281c4037f21f0af66b1815118ef75dacb33bfd72ffcf03a"
+content-hash = "212ca55d9f279d0c28568ed456d56c80cd758273cae56006b1c473b06f38d61d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1790,6 +1790,26 @@ files = [
 ]
 
 [[package]]
+name = "typst"
+version = "0.11.1"
+description = "Python binding to typst"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typst-0.11.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ec50fc97f8afe6da1f8787a72f77f04ddf14e007c88a1b130cb8122a405e4e63"},
+    {file = "typst-0.11.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8af0dabc95a761b07f19c4551da9176bc1b408a9abf9d5d0ab93da3d616abf6"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d6bf84d7e1c8402241d10874a4dc4df4995dcff0a581c47b1def92cc4de322b"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11c925fab98fdce6b3f8c498c399eed7224d7a315348aa46e2bb0d9a40af5baa"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:812b99f617aabb599508e132cdc881a751d89ad32504def774d3e3b765425872"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:75313042a605c15649f23eb074c5df34bca66f5b921cd043651afd80ff3ad9f0"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ffba53328e317b9b0a4e9d05573c98c7f7d4e555259e1ff5a9a2169a85232d71"},
+    {file = "typst-0.11.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef8e44bec7a2e168a92aec2fa8008328b630d137753c0550ba654c7855d2893a"},
+    {file = "typst-0.11.1-cp37-abi3-win32.whl", hash = "sha256:e2ccebab8f9fc49b2b212d6af0e349aa6cd8fc043c343bf5719aa1ef7dae354f"},
+    {file = "typst-0.11.1-cp37-abi3-win_amd64.whl", hash = "sha256:3874f7910687406ee7e80de1aec58487c305b76893b50a3a869496105a5767a5"},
+    {file = "typst-0.11.1.tar.gz", hash = "sha256:56a336fef1dbec6ae678d87d680a90ad07c8739bc0599b54fdd7fa351a4efa56"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1943,4 +1963,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "56ecbd30a95a09c65cef191fda4846952082ca086eca97a46cb2547e8ec4a7de"
+content-hash = "6795e79a85089141b6ae1c03b276e20a83fed0bdc15a14a624f75bbedb8b6ea8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ ignore = [
     "RUF029",
     "S311",
     "SIM102", "SIM108",
+    "S404", # S404 is bugged and doesn't respect noqa
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ emoji = "2.12.1"
 pyjokes = "0.8.3"
 pydantic = { version = "2.6.4", extras = ["dotenv"]}
 pydantic-settings = "2.2.1"
-typst = "^0.12.0"
-anyio = "^4.6.2.post1"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ emoji = "2.12.1"
 pyjokes = "0.8.3"
 pydantic = { version = "2.6.4", extras = ["dotenv"]}
 pydantic-settings = "2.2.1"
-typst = "^0.11.1"
+typst = "^0.12.0"
 anyio = "^4.6.2.post1"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ emoji = "2.12.1"
 pyjokes = "0.8.3"
 pydantic = { version = "2.6.4", extras = ["dotenv"]}
 pydantic-settings = "2.2.1"
+typst = "^0.11.1"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pyjokes = "0.8.3"
 pydantic = { version = "2.6.4", extras = ["dotenv"]}
 pydantic-settings = "2.2.1"
 typst = "^0.11.1"
+anyio = "^4.6.2.post1"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Relevant Issues
Closes #1623.

## Description
- The overall structure is based on the Latex cog, with about the same features (caching, support for code blocks, etc)
- Refactored some utility functions (such as the codeblock regex) out of the Latex cog to reuse them here.
- Initially I was going to use the `typst` PyPI package, but while it works, it had a weird issue where (only in the bot's container and not on my computer) it needed ~1GB RAM to render the simplest things. I failed to figure out what caused this, and as a result I switched to using the CLI, which is less hungry (~100MB for sane inputs) and supports some nice features the python bindings don't (such as taking the input from stdin with no files involved).
- The typst executable is not included, but instead downloaded (with hash verification) at cog load time, from a link that can be altered with envvars, and then stored in the cache.
- If the global typst packages directory is missing, a default set of packages is installed and the directory then `chmod`ed to not allow writes.
- To render, the `typst` executable gets called in a subprocess, with a time limit (and gets killed if the limit is exceeded) and a memory usage rlimit.
- If the rendered image is too big, this is considered an error (to hopefully make it a bit harder to maliciously post big outputs).
- The rendered image also gets manually cropped to only the content and not the white background (typst's own formatting doesn't seem to have an option for it, and this is the more resilient choice anyway).

Security-wise, the typst invocation sets `--root` to an empty temporary directory, which in theory should prevent access to any files outside of it. As for the packages, even though arbitrary typst packages are supposed to be safe, I still chose to prevent installation of them at runtime by locking the packages directory from writes. Nevertheless, I am pretty worried about the security of this and want someone to take a second look at whether it's exploitable. And of course, if there's ever a new vulnerability in `typst` itself, that'd potentially make Lancebot's environment vulnerable.

## Did you:
- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
