### PR TITLE
Adjust user input to title cased when looking up name

### DIFF
--- a/bot/exts/utilities/colour.py
+++ b/bot/exts/utilities/colour.py
@@ -163,7 +163,7 @@ class Colour(commands.Cog):
     @colour.command()
     async def name(self, ctx: commands.Context, *, user_colour_name: str) -> None:
         """Create an embed from a name input."""
-        hex_colour = self.match_colour_name(ctx, user_colour_name)
+        hex_colour = self.match_colour_name(ctx, user_colour_name.title())
         if hex_colour is None:
             name_error_embed = discord.Embed(
                 title="No colour match found.",


### PR DESCRIPTION
Closes #1650 

## Description
Made the user input title cased when looking up the name in the reference color list. 

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] Read all the comments in this template?
- [X] Ensure there is an issue open, or link relevant discord discussions?
- [X] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
