### PR TITLE
Madlibs - change zip parameter "strict" to False

### DIFF
--- a/bot/exts/fun/madlibs.py
+++ b/bot/exts/fun/madlibs.py
@@ -116,7 +116,7 @@ class Madlibs(commands.Cog):
         self.checks.remove(author_check)
 
         story = []
-        for value, blank in zip(random_template["value"], blanks, strict=True):
+        for value, blank in zip(random_template["value"], blanks, strict=False):
             story.append(f"{value}__{blank}__")
 
         # In each story template, there is always one more "value"


### PR DESCRIPTION
## Relevant Issues
Link to discussion: https://discord.com/channels/267624335836053506/635950537262759947/1401476352758251520

## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Changed one line of the Madlibs code which was causing a "ValueError: zip() argument 2 is shorter than argument 1" and, as a result, not displaying the final Madlib. All I had to do is change the "strict" parameter in the zip() function call to False and that fixed the issue.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
