### PR TITLE
Dadjoke

### DIFF
--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -164,8 +164,10 @@ class Fun(Cog):
         if category == "dad":
             async with aiohttp.ClientSession() as session, session.get(
                 "https://icanhazdadjoke.com",
-                headers={"Accept":"application/json"
-            }) as res:
+                headers={
+                    "Accept":"application/json",
+                    "User-Agent": "Sir-lancebot"
+                }) as res:
                 if res.status == 200:
                     data = await res.json()
                     await ctx.send(data["joke"])

--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Literal
 
+import aiohttp
 import pyjokes
 from discord import Embed
 from discord.ext import commands
@@ -153,10 +154,26 @@ class Fun(Cog):
         await self._caesar_cipher(ctx, offset, msg, left_shift=True)
 
     @commands.command()
-    async def joke(self, ctx: commands.Context, category: Literal["neutral", "chuck", "all"] = "all") -> None:
-        """Retrieves a joke of the specified `category` from the pyjokes api."""
-        joke = pyjokes.get_joke(category=category)
-        await ctx.send(joke)
+    async def joke(self, ctx: commands.Context, category: Literal["dad", "neutral", "chuck", "all"] = "all") -> None:
+        """
+        Retrieves a joke of the specified `category` from the pyjokes api.
+
+        - dad uses icanhazdadjoke.
+        - others use pyjokes.
+        """
+        if category == "dad":
+            async with aiohttp.ClientSession() as session, session.get(
+                "https://icanhazdadjoke.com",
+                headers={"Accept":"application/json"
+            }) as res:
+                if res.status == 200:
+                    data = await res.json()
+                    await ctx.send(data["joke"])
+                else:
+                    await ctx.send("There is no dad joke now")
+        else:
+            joke = pyjokes.get_joke(category=category)
+            await ctx.send(joke)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Literal
 
-import aiohttp
 import pyjokes
 from discord import Embed
 from discord.ext import commands
@@ -162,17 +161,15 @@ class Fun(Cog):
         - others use pyjokes.
         """
         if category == "dad":
-            async with aiohttp.ClientSession() as session, session.get(
+            async with self.bot.http_session.get(
                 "https://icanhazdadjoke.com",
                 headers={
                     "Accept":"application/json",
-                    "User-Agent": "Sir-lancebot"
+                    "User-Agent": "Sir-lancebot (https://github.com/python-discord/sir-lancebot)"
                 }) as res:
-                if res.status == 200:
-                    data = await res.json()
-                    await ctx.send(data["joke"])
-                else:
-                    await ctx.send("There is no dad joke now")
+                res.raise_for_status()
+                data = await res.json()
+                await ctx.send(data["joke"])
         else:
             joke = pyjokes.get_joke(category=category)
             await ctx.send(joke)


### PR DESCRIPTION
## Relevant Issues
<!--
It is mandatory to link to an issue that has been approved by a Core Developer, indicated by an "approved" label.
Issues can be skipped with explicit core dev approval, but you have to link the discussion.
--> https://github.com/python-discord/sir-lancebot/issues/1691?notification_referrer_id=NT_kwDOBivkC7UxODE0MTkwMjE5MjoxMDM1Mzk3MjM#event-19124053085

<!-- Link the issue by typing: "Closes #<number>" (Closes #0 to close issue 0 for example). -->


## Description
<!-- Describe what changes you made, and how you've implemented them. -->
Changes made:
- Extend the existing 'joke' command with 'dad' category using icanhazdadjoke API
- Keep the existing joke categories (chuck, neutral, all) 
How it's implemented:
- When dad joke is called, an asynchronous HTTP GET request is made to https://icanhazdadjoke.com with aiohttp
- Implement user agent to comply with icanhazdadjoke API policy
- The joke from JSON is sent back to the user with ctx.send()
- Linted and tested in a new python file before adding the code to fun.py

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
