### PR TITLE
chore: assert uv lock is locked in ci and pre-commit

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv sync --frozen
+        run: uv sync --locked
 
       # Attempt to run the bot. Setting `IN_CI` to true, so bot.run() is never called.
       # This is to catch import and cog setup errors that may appear in PRs, to avoid crash loops if merged.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,17 @@ repos:
 
   - repo: local
     hooks:
+      - id: uv-lock
+        name: uv lock
+        description: Checks the validity of the uv.lock file.
+        entry: uv lock
+        language: system
+        files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
+        pass_filenames: false
       - id: ruff
         name: ruff
         description: Run ruff linting
-        entry: uv run ruff check --force-exclude
+        entry: uv run --frozen ruff check --force-exclude
         language: system
         'types_or': [python, pyi]
         require_serial: true


### PR DESCRIPTION
see https://github.com/python-discord/bot/pull/3416 for reference
