### PR TITLE
Fix regex for 'spooky' trigger pattern

### DIFF
--- a/bot/exts/holidays/holidayreact.py
+++ b/bot/exts/holidays/holidayreact.py
@@ -75,7 +75,7 @@ Halloween = Holiday([Month.OCTOBER], {
     "jack-o-lantern": Trigger(r"\bjack-o-lantern\b", ["\U0001F383"]),
     "pumpkin": Trigger(r"\bpumpkin\b", ["\U0001F383"]),
     "skeleton": Trigger(r"\bskeleton\b", ["\U0001F480"]),
-    "spooky": Trigger(r"\bspo{2,}[k|p][i|y](er|est)?\b", ["\U0001F47B"]),
+    "spooky": Trigger(r"\bspo{2,}[kp][iy](er|est)?\b", ["\U0001F47B"]),
     }
 )
 Hanukkah = Holiday([Month.NOVEMBER, Month.DECEMBER], {


### PR DESCRIPTION
## Relevant Issues
https://discordapp.com/channels/267624335836053506/635950537262759947/1432895836609712128
<img width="768" height="130" alt="image" src="https://github.com/user-attachments/assets/16af660c-b046-464c-a330-c14c124f764a" />

## Description
Removed `|` used within `[]` in a regex pattern where the intended purpose seems to have been to use it as an "or" pattern, but since it's inside `[]` (as opposed to `()`), this is redundant and now it can match patterns like `spoo||aaaa`

That said, maybe it should be left as is (as a little Easter Egg)?

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
