### PR TITLE
Add `http` as additional alias for `http_status`

### DIFF
--- a/bot/exts/fun/status_codes.py
+++ b/bot/exts/fun/status_codes.py
@@ -27,8 +27,8 @@ class HTTPStatusCodes(commands.Cog):
         self.bot = bot
 
     @commands.group(
-        name="http_status",
-        aliases=("http", "status", "httpstatus"),
+        name="http",
+        aliases=("http_status", "httpstatus", "status"),
         invoke_without_command=True,
     )
     async def http_status_group(self, ctx: commands.Context, code: int) -> None:


### PR DESCRIPTION
## Relevant Issues
Discussion: https://discord.com/channels/267624335836053506/267624335836053506/1436171142418403430

## Description

Added `http` as additional alias for `http_status`.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
