### PR TITLE
Fix trashcan delete reaction in DMs

### DIFF
--- a/bot/exts/core/help.py
+++ b/bot/exts/core/help.py
@@ -4,7 +4,7 @@ import itertools
 from contextlib import suppress
 from typing import NamedTuple
 
-from discord import Colour, DMChannel, Embed, HTTPException, Message, NotFound, Object, RawReactionActionEvent
+from discord import ChannelType, Colour, Embed, HTTPException, Message, NotFound, Object, RawReactionActionEvent
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Cog as DiscordCog, Command, Context
 from pydis_core.utils.logging import get_logger
@@ -206,7 +206,7 @@ class HelpSession:
         try:
             # We need to get the actual message and user objects for remove_reaction
             channel = self._bot.get_channel(payload.channel_id)
-            if channel and not isinstance(channel, DMChannel):
+            if channel and channel.type != ChannelType.private:
                 # channel is None in DMs, this condition skips reaction removal in DMs to prevent exceptions
                 message = channel.get_partial_message(payload.message_id)
                 await message.remove_reaction(payload.emoji, Object(id=payload.user_id))


### PR DESCRIPTION
## Relevant Issues
Closes #1450



## Description
Added on_raw_reaction_add handler to support reaction events in DMs, as the standard on_reaction_add doesn't fire in DM contexts.

Original Implementation @ [OSCxSST/sir-lancebot-SLB/pull/20](https://github.com/OSCxSST/sir-lancebot-SLB/pull/20)

## I Did:


- [x] Join the [**Python Discord Community**](https://discord.gg/python)
- [x] Read all the comments in this template
- [x] Ensure there is an issue open, or link relevant discord discussions
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)
