### PR TITLE
Fix the `wolfram` command

### DIFF
--- a/bot/exts/utilities/wolfram.py
+++ b/bot/exts/utilities/wolfram.py
@@ -120,7 +120,7 @@ async def get_pod_pages(ctx: Context, bot: Bot, query: str) -> list[tuple[str, s
         request_url = QUERY.format(request="query")
 
         async with bot.http_session.get(url=request_url, params=params) as response:
-            json = await response.json(content_type="text/plain")
+            json = await response.json()
 
         result = json["queryresult"]
         log_full_url = f"{request_url}?{urlencode(params)}"


### PR DESCRIPTION
## Relevant Issues

Closes #1019

## Description

Removed the content type argument from the response's JSON decoder to use a default content type.

The reason to change it is because the API returns a response with a `application/json` content type, but the decoder expects the `plain/text` content type. As a result, the decoder throws an exception about a "JSON with unexpected mimetype".

An example of an output from the command that didn't work previously:

<img width="488" height="473" alt="An example of a work" src="https://github.com/user-attachments/assets/e3e945f9-f9ee-48e4-b870-179ef67a31ac" />

## Did you:

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] Read all the comments in this template?
- [x] Ensure there is an issue open, or link relevant discord discussions?
- [x] Read and agree to the [contributing guidelines](https://pythondiscord.com/pages/contributing/contributing-guidelines/)?
